### PR TITLE
Fix booking time handling: generate start_time and  end_time 

### DIFF
--- a/Frontend/src/components/pages/TraineeBookingFlow.jsx
+++ b/Frontend/src/components/pages/TraineeBookingFlow.jsx
@@ -40,20 +40,14 @@ const TraineeBookingFlow = () => {
 
 	// here we set up booking obj that will be sent to backend
 	const createBookingDetailsObj = (bookingFormData) => {
-		// const formattedDate = selectedDate.toLocaleDateString("en-CA"); this now comes form url
+		const startDateTime = new Date(`${selectedDate}T${selectedTime}:00`);
+		const endDateTime = new Date(startDateTime.getTime() + 60 * 60 * 1000);
 
 		const bookingDetailsObj = {
 			trainee_name: bookingFormData.traineeName,
 			trainee_email: bookingFormData.traineeEmail,
-			//start_date and start_time icome from the state
-			//converted in fix ----- start
-			// start_date: selectedDate,
-			// // on fornt end I had start_date as date only but backedn uses date and time in one so below
-			// start_time: selectedTime, now below this matches backend
-			// start_date and start_time are one var
-			start_time: `${selectedDate}T${selectedTime}:00Z`,
-			//below is hardcoded as in fe it only exists as 1 hour meeting and no end_time exists
-			end_time: `${selectedDate}T23:59:00Z`,
+			start_time: startDateTime.toISOString(),
+			end_time: endDateTime.toISOString(),
 			volunteer_name: activeVolunteer.name,
 			volunteer_email: activeVolunteer.email,
 		};
@@ -71,7 +65,7 @@ const TraineeBookingFlow = () => {
 			})
 			.catch((error) => console.log("Error:", error));
 	};
-
+	
 	return (
 		<div className="booking-box">
 			<div className="session-details-col">


### PR DESCRIPTION
Fix booking time handling: generate dynamic end_time and use ISO timestamps

- Created startDateTime using selected date and time
- Replaced hardcoded `end_time` with computed value (+1 hour from start_time)
- Switched from string concatenation to Date objects
- Ensured correct ISO formatting using toISOString()
- Improved consistency with backend datetime expectations

**Why?**

end_time was hardcoded providing incorrect meeting duration
start_time was manually formatted produced error in initial hour

**Results** 
Ensures correct scheduling duration (1 hour)
Correct ISO formatting prevents timezone and formatting issues

Before:
<img width="720" height="125" alt="image" src="https://github.com/user-attachments/assets/1453ac8c-5e62-46e7-aa3f-c170d9facabe" />

After:
<img width="720" height="135" alt="image" src="https://github.com/user-attachments/assets/10c7de10-144e-4fe0-b153-fb8c848ea859" />
