### PR TITLE
Reafctor MeView to Current Profile View

### DIFF
--- a/Backend/core/tests/test_current_user_profile.py
+++ b/Backend/core/tests/test_current_user_profile.py
@@ -12,7 +12,7 @@ def test_current_user_profile_get_authenticated(client, django_user_model):
     )
     client.login(username="sara", password="securepass123")
 
-    response = client.get("/api/me/")
+    response = client.get("/api/profile/")
     assert response.status_code == 200
 
     data = response.json()
@@ -23,7 +23,7 @@ def test_current_user_profile_get_authenticated(client, django_user_model):
 
 @pytest.mark.django_db
 def test_current_user_profile_get_unauthenticated(client):
-    response = client.get("/api/me/")
+    response = client.get("/api/profile/")
     assert response.status_code == 403
 
 
@@ -39,7 +39,7 @@ def test_current_user_profile_patch_updates_role(client, django_user_model):
     client.login(username="emiliano", password="strongpass456")
 
     response = client.patch(
-        "/api/me/", data={"role": "volunteer"}, content_type="application/json"
+        "/api/profile/", data={"role": "volunteer"}, content_type="application/json"
     )
     assert response.status_code == 200
 
@@ -62,7 +62,7 @@ def test_current_user_profile_patch_invalid_role(client, django_user_model):
     client.login(username="kaska", password="securepass678")
 
     response = client.patch(
-        "/api/me/",
+        "/api/profile/",
         data={"role": "hacker"},  # invalid role
         content_type="application/json",
     )

--- a/Backend/core/urls.py
+++ b/Backend/core/urls.py
@@ -1,7 +1,7 @@
 from django.urls import path
 
 from .views import create_meeting_view
-from .views import MeView
+from .views import CurrentProfileView
 from .views import UserListCreateView, UserDetailView, SlotRuleCreateView
 
 # API routes for calendar-related actions
@@ -10,6 +10,6 @@ urlpatterns = [
     # API routes for Users in database Endpoints
     path("users/", UserListCreateView.as_view(), name="user-list-create"),
     path("users/<int:pk>/", UserDetailView.as_view(), name="user-detail"),
-    path("me/", MeView.as_view(), name="me"),
+    path("profile/", CurrentProfileView.as_view(), name="current-profile"),
     path("slot-rules/", SlotRuleCreateView.as_view(), name="slot-rule-create"),
 ]

--- a/Backend/core/views.py
+++ b/Backend/core/views.py
@@ -19,14 +19,14 @@ class CreateMeetingView(APIView):
     permission_classes = [IsAuthenticated]
 
     def post(self, request):
-        
+
         serializer = BookingSerializer(data=request.data)
 
         if not serializer.is_valid():
             return Response(serializer.errors, status=status.HTTP_400_BAD_REQUEST)
 
         validated = serializer.validated_data
-        
+
         try:
             result = create_google_meeting(
                 start_time=validated["start_time"],
@@ -48,10 +48,9 @@ class CreateMeetingView(APIView):
                 "start": result["start"],
                 "end": result["end"],
             },
-          
             status=status.HTTP_201_CREATED,
-
         )
+
 
 class UserListCreateView(generics.ListCreateAPIView):
     queryset = User.objects.all().order_by("id")
@@ -65,16 +64,12 @@ class UserDetailView(generics.RetrieveUpdateAPIView):
     serializer_class = UserSerializer
 
 
-
 class CurrentProfileView(generics.RetrieveUpdateAPIView):
-
     serializer_class = UserSerializer
     permission_classes = [permissions.IsAuthenticated]
 
     def get_object(self):
         return self.request.user
-
-
 
 
 class SlotRuleCreateView(generics.CreateAPIView):

--- a/Backend/core/views.py
+++ b/Backend/core/views.py
@@ -1,4 +1,3 @@
-
 # Not used in this view, but commonly imported for rendering HTML templates.
 from django.shortcuts import render
 import json
@@ -10,11 +9,12 @@ from django.views.decorators.csrf import csrf_exempt
 from .google_calendar_service import create_google_meeting
 from .serializers.booking_serializer import BookingSerializer
 
-#Django Rest Framework and serializer for endpoints
+# Django Rest Framework and serializer for endpoints
 from rest_framework import generics, permissions
 from .models import User, SlotRule
 from .user_serializers import UserSerializer
 from .serializers.slot_rule_serializer import SlotRuleSerializer
+
 
 @csrf_exempt
 @require_POST
@@ -28,8 +28,6 @@ def create_meeting_view(request):
             return JsonResponse(serializer.errors, status=400)
         validated = serializer.validated_data
 
-
-       
         result = create_google_meeting(
             start_time=validated["start_time"],
             end_time=validated["end_time"],
@@ -44,7 +42,7 @@ def create_meeting_view(request):
                 "meet_link": result["meet_link"],
                 "start": result["start"],
                 "end": result["end"],
-                },
+            },
             status=201,
         )
 
@@ -56,29 +54,30 @@ def create_meeting_view(request):
 
 
 class UserListCreateView(generics.ListCreateAPIView):
-    
     queryset = User.objects.all().order_by("id")
 
     serializer_class = UserSerializer
 
+
 class UserDetailView(generics.RetrieveUpdateAPIView):
-    
     queryset = User.objects.all()
 
     serializer_class = UserSerializer
 
-class MeView(generics.RetrieveUpdateAPIView):
- 
+
+class CurrentProfileView(generics.RetrieveUpdateAPIView):
     serializer_class = UserSerializer
     permission_classes = [permissions.IsAuthenticated]
 
     def get_object(self):
-        return self.request.user   
-class SlotRuleCreateView(generics.CreateAPIView):
+        return self.request.user
 
+
+class SlotRuleCreateView(generics.CreateAPIView):
     queryset = SlotRule.objects.all()
     serializer_class = SlotRuleSerializer
     permission_classes = [permissions.IsAuthenticated]
-    #Always assign the slot rule to the logged-in user
+
+    # Always assign the slot rule to the logged-in user
     def perform_create(self, serializer):
         serializer.save(volunteer=self.request.user)


### PR DESCRIPTION
This PR refactors the MeView class to follow clearer naming practices by renaming it to CurrentProfileView. The new name better communicates the intent of the endpoint which represents the profile of the currently authenticated user.

Purpose of the Endpoint
 1. Since all users authenticate via Google, they will not be updating core identity fields such as email or username through this endpoint.
2. The endpoint exists to allow users to view their own profile and, in the future, update dynamic attributes such as:
 Group choices (e.g.ITP, SDC,launch for trainees)
3. Language or specialization tags (e.g., volunteers marking themselves as Python,JavaScript specialists)
4. These attributes are expected to evolve as users progress through courses or host sessions, making a dedicated self‑service profile endpoint valuable.

**Note:**
This will need to be approved before the testing PR for this endpoint and view (https://github.com/SaraTahir28/Pair-Scheduling-APP/pull/92) and then in testing PR we will need to update routing to api/profile from api/me.