### PR TITLE
Removing import and path in urls related to MeView

### DIFF
--- a/Backend/core/urls.py
+++ b/Backend/core/urls.py
@@ -2,7 +2,6 @@ from django.urls import path
 
 from .views import CurrentProfileView
 from .views import CreateMeetingView
-from .views import MeView
 from .views import AvailableSlotsView
 from .views import UserListCreateView, UserDetailView, SlotRuleCreateView
 
@@ -12,7 +11,6 @@ urlpatterns = [
     # API routes for Users in database Endpoints
     path("users/", UserListCreateView.as_view(), name="user-list-create"),
     path("users/<int:pk>/", UserDetailView.as_view(), name="user-detail"),
-    path("me/", MeView.as_view(), name="me"),
     path("available-slots/", AvailableSlotsView.as_view(), name="available-slots"),
     path("profile/", CurrentProfileView.as_view(), name="current-profile"),
     path("slot-rules/", SlotRuleCreateView.as_view(), name="slot-rule-create"),


### PR DESCRIPTION

Cleaned up urls.py by removing the unused MeView import and its corresponding route.