### PR TITLE
Cypress tests for the Volunteer flow

### DIFF
--- a/Frontend/cypress/e2e/Integration-Volunteer.cy.jsx
+++ b/Frontend/cypress/e2e/Integration-Volunteer.cy.jsx
@@ -1,0 +1,108 @@
+describe("Volunteer flow", () => {
+	it("allows volunteer to save a single date availability", () => {
+		cy.intercept("GET", "**/auth/user/", {
+			statusCode: 200,
+			body: {
+				id: 1,
+				name: "Duncan Parkinson",
+				email: "duncan@test.com",
+				is_volunteer: true,
+			},
+		}).as("getUser");
+
+		cy.visit("/volunteer-dash");
+		cy.wait("@getUser");
+
+		cy.contains(
+			"Let's start by selecting your availability for 1:1 sessions."
+		).should("be.visible");
+
+		cy.get('input[type="date"]').clear().type("2026-05-20");
+		cy.get('input[type="date"]').should("have.value", "2026-05-20");
+		cy.get('input[type="time"]').clear().type("10:00");
+		cy.get('input[type="time"]').should("have.value", "10:00");
+
+		cy.contains("button", "Add to list").click();
+
+		cy.on("window:alert", (text) => {
+			expect(text).to.contains("Availability is saved.");
+		});
+
+		cy.contains(/save all/i).click();
+
+		cy.contains("Upcoming sessions").should("be.visible");
+		cy.get(".all-cards-container").should("be.visible");
+	});
+
+	it("allows volunteer to save a recurring availability", () => {
+		cy.intercept("GET", "**/auth/user/", {
+			statusCode: 200,
+			body: {
+				id: 1,
+				name: "Duncan Parkinson",
+				email: "duncan@test.com",
+				is_volunteer: true,
+			},
+		}).as("getUser");
+
+		cy.visit("/volunteer-dash");
+		cy.wait("@getUser");
+
+		cy.contains(
+			"Let's start by selecting your availability for 1:1 sessions."
+		).should("be.visible");
+
+		cy.get('input[type="date"]').clear().type("2026-05-15");
+		cy.get('input[type="date"]').should("have.value", "2026-05-15");
+		cy.get('input[type="time"]').clear().type("14:30");
+		cy.get('input[type="time"]').should("have.value", "14:30");
+
+		cy.get(".form-checkbox").should("not.be.checked");
+		cy.get(".form-checkbox").check();
+		cy.get(".form-checkbox").should("be.checked");
+
+		cy.contains("Select date").should("not.exist");
+		cy.contains("label", "Starting on").should("be.visible");
+		cy.contains("This session will repeat every Friday").should("be.visible");
+
+		cy.contains("button", "Add to list").click();
+
+		cy.on("window:alert", (text) => {
+			expect(text).to.contains("Availability is saved.");
+		});
+
+		cy.contains(/save all/i).click();
+
+		cy.contains("Upcoming sessions").should("be.visible");
+		cy.get(".all-cards-container").should("be.visible");
+	});
+
+	it("allows volunteer to remove an item from the basket", () => {
+		cy.intercept("GET", "**/auth/user/", {
+			statusCode: 200,
+			body: {
+				id: 1,
+				name: "Duncan Parkinson",
+				email: "duncan@test.com",
+				is_volunteer: true,
+			},
+		}).as("getUser");
+
+		cy.visit("/volunteer-dash");
+		cy.wait("@getUser");
+
+		cy.get('input[type="date"]').clear().type("2026-05-20");
+		cy.get('input[type="date"]').should("have.value", "2026-05-20");
+		cy.get('input[type="time"]').clear().type("10:00");
+		cy.get('input[type="time"]').should("have.value", "10:00");
+
+		cy.contains("button", "Add to list").click();
+
+		cy.contains("Entries to save:").should("be.visible");
+
+		cy.contains("✕").click();
+
+		cy.contains("Entries to save:").should("not.exist");
+		cy.contains(/save all/i).should("not.exist");
+	});
+});

--- a/Frontend/cypress/e2e/Integration-VolunteerOnboarding.cy.jsx
+++ b/Frontend/cypress/e2e/Integration-VolunteerOnboarding.cy.jsx
@@ -1,15 +1,16 @@
 describe("Volunteer flow", () => {
-	it("allows volunteer to save a single date availability", () => {
+	beforeEach(() => {
 		cy.intercept("GET", "**/auth/user/", {
 			statusCode: 200,
 			body: {
 				id: 1,
 				name: "Duncan Parkinson",
-				email: "duncan@test.com",
-				is_volunteer: true,
+				email: "duncan@example.com",
 			},
 		}).as("getUser");
+	});
 
+	it("allows volunteer to save a single date availability", () => {
 		cy.visit("/volunteer-dash");
 		cy.wait("@getUser");
 
@@ -35,16 +36,6 @@ describe("Volunteer flow", () => {
 	});
 
 	it("allows volunteer to save a recurring availability", () => {
-		cy.intercept("GET", "**/auth/user/", {
-			statusCode: 200,
-			body: {
-				id: 1,
-				name: "Duncan Parkinson",
-				email: "duncan@test.com",
-				is_volunteer: true,
-			},
-		}).as("getUser");
-
 		cy.visit("/volunteer-dash");
 		cy.wait("@getUser");
 
@@ -78,16 +69,6 @@ describe("Volunteer flow", () => {
 	});
 
 	it("allows volunteer to remove an item from the basket", () => {
-		cy.intercept("GET", "**/auth/user/", {
-			statusCode: 200,
-			body: {
-				id: 1,
-				name: "Duncan Parkinson",
-				email: "duncan@test.com",
-				is_volunteer: true,
-			},
-		}).as("getUser");
-
 		cy.visit("/volunteer-dash");
 		cy.wait("@getUser");
 
@@ -107,16 +88,6 @@ describe("Volunteer flow", () => {
 	});
 
 	it("hides onboarding after successful slots save", () => {
-		cy.intercept("GET", "**/auth/user/", {
-			statusCode: 200,
-			body: {
-				id: 1,
-				name: "Duncan Parkinson",
-				email: "duncan@test.com",
-				is_volunteer: true,
-			},
-		}).as("getUser");
-
 		cy.visit("/volunteer-dash");
 		cy.wait("@getUser");
 

--- a/Frontend/cypress/e2e/Integration-VolunteerOnboarding.cy.jsx
+++ b/Frontend/cypress/e2e/Integration-VolunteerOnboarding.cy.jsx
@@ -105,4 +105,33 @@ describe("Volunteer flow", () => {
 		cy.contains("Entries to save:").should("not.exist");
 		cy.contains(/save all/i).should("not.exist");
 	});
+
+	it("hides onboarding after successful slots save", () => {
+		cy.intercept("GET", "**/auth/user/", {
+			statusCode: 200,
+			body: {
+				id: 1,
+				name: "Duncan Parkinson",
+				email: "duncan@test.com",
+				is_volunteer: true,
+			},
+		}).as("getUser");
+
+		cy.visit("/volunteer-dash");
+		cy.wait("@getUser");
+
+		cy.get('input[type="date"]').clear().type("2026-05-20");
+		cy.get('input[type="date"]').should("have.value", "2026-05-20");
+		cy.contains("button", "Add to list").click();
+
+		cy.contains(/save all/i).click();
+
+		cy.contains("Let's start by selecting your availability").should(
+			"not.exist"
+		);
+		cy.get("form").should("not.exist");
+		cy.contains("Upcoming sessions").should("be.visible");
+		cy.get(".all-cards-container").should("be.visible");
+		cy.contains("button", "Add to list").should("not.exist");
+	});
 });

--- a/Frontend/src/components/groups/AddingSlotsBasket.jsx
+++ b/Frontend/src/components/groups/AddingSlotsBasket.jsx
@@ -41,7 +41,7 @@ const AddingSlotsBasket = ({ addedSlots, removeSlot, saveAll }) => {
 			))}
 
 			<ActionBtn additionalBtnClass="btn-primary" onClick={saveAll}>
-				Save All
+				Save all
 			</ActionBtn>
 		</div>
 	);

--- a/Frontend/src/components/pages/VolunteerDash.jsx
+++ b/Frontend/src/components/pages/VolunteerDash.jsx
@@ -10,6 +10,7 @@ import VolunteerViewSession from "../groups/VolunteerViewSession";
 import VolunteerAvailabilityForm from "../groups/VolunteerAvailabilityForm";
 import { ActionBtn } from "../elements/Button";
 import { useAuth } from "../../AuthContext";
+import duncanImg from "../../assets/duncan.png";
 
 const VolunteerDash = () => {
 	const { id } = useParams();
@@ -18,6 +19,9 @@ const VolunteerDash = () => {
 
 	const activeVolunteer =
 		volunteersDetails.find((v) => v.email === user?.email) || user;
+	if (activeVolunteer && !activeVolunteer.img) {
+		activeVolunteer.img = duncanImg;
+	}
 
 	const [allBookedSessionsForAllUsers, setAllBookedSessionsForAllUsers] =
 		useState(bookedSessions);

--- a/Frontend/src/components/pages/VolunteerDash.jsx
+++ b/Frontend/src/components/pages/VolunteerDash.jsx
@@ -16,16 +16,12 @@ const VolunteerDash = () => {
 	const { user } = useAuth();
 	const editSessionMode = window.location.pathname.includes("edit");
 
-	//here we select state of activeVolunteer that will be passed to session details volunteers div
-	//for now Duncan is an active volunteer
-	const [activeVolunteer, setActiveVolunteer] = useState(
-		volunteersDetails.find((volunteer) => volunteer.id === 1)
-	);
+	const activeVolunteer =
+		volunteersDetails.find((v) => v.email === user?.email) || user;
 
 	const [allBookedSessionsForAllUsers, setAllBookedSessionsForAllUsers] =
 		useState(bookedSessions);
 
-	//adding the step of adding slots before form is sent
 	const [hasUserSetAvailability, setHasUserSetAvailability] = useState(false);
 	const [temporaryAddedSlotsStorage, setTemporaryAddedSlotsStorage] = useState(
 		[]
@@ -45,10 +41,8 @@ const VolunteerDash = () => {
 	const activeVolunteerSessions = allBookedSessionsForAllUsers.filter(
 		(session) => session.volunteerId === activeVolunteer.id
 	);
-	//set up where all booked sessions will go on cards
 	const renderedSessions = [];
 
-	//for now this is for volunteer only bc trainee will have limitations of times and will see rerender of cal + times
 	const saveEditedSession = (updatedSessionFromCard) => {
 		const updatedSessions = allBookedSessionsForAllUsers.map((session) => {
 			if (session.id === updatedSessionFromCard.id) {
@@ -56,12 +50,9 @@ const VolunteerDash = () => {
 			}
 			return session;
 		});
-		// rerender
 		setAllBookedSessionsForAllUsers(updatedSessions);
 	};
 
-	//function for deleting booked session sent as props to BookingCard.jsx, runs when delete is confirmed
-	// for the id we want to delete - grab all other ids and pass to update state
 	const deleteBookedSession = (idToDelete) => {
 		const varPassToUpdateStateBookedSessions =
 			allBookedSessionsForAllUsers.filter(
@@ -89,7 +80,6 @@ const VolunteerDash = () => {
 		//      .catch((error) => console.log("Error:", error));
 	};
 
-	//check all sessions from active vol and find id and match to traineeDetails by id
 	activeVolunteerSessions.forEach((session) => {
 		traineeDetails.forEach((trainee) => {
 			if (trainee.id === session.traineeId) {
@@ -110,7 +100,6 @@ const VolunteerDash = () => {
 			temporaryAddedSlotsStorage.filter((_, index) => index !== indexToRemove)
 		);
 	};
-	// once completed adding slots
 	return (
 		<div className="booking-box">
 			<div className="session-details-col">
@@ -138,7 +127,7 @@ const VolunteerDash = () => {
 						/>
 					</div>
 				)}
-				{/* view after adding sessions */}
+
 				{hasUserSetAvailability && (
 					<>
 						{id ? (

--- a/Frontend/src/components/pages/VolunteerDash.jsx
+++ b/Frontend/src/components/pages/VolunteerDash.jsx
@@ -9,10 +9,11 @@ import VolunteerViewSession from "../groups/VolunteerViewSession";
 
 import VolunteerAvailabilityForm from "../groups/VolunteerAvailabilityForm";
 import { ActionBtn } from "../elements/Button";
+import { useAuth } from "../../AuthContext";
 
 const VolunteerDash = () => {
 	const { id } = useParams();
-
+	const { user } = useAuth();
 	const editSessionMode = window.location.pathname.includes("edit");
 
 	//here we select state of activeVolunteer that will be passed to session details volunteers div


### PR DESCRIPTION
This PR is for the Cypress integration test for the Volunteer onboarding.

Changes
Cypress: Added tests for single/recurring slots, basket removal, and dashboard rendering.
Auth Integration: Switched VolunteerDash to useAuth().
Volunteer Flow: Added fallback profile image (duncan.png).

Testing
cd Frontend && npm run dev
npx cypress open
Run e2e and select Integration-Volunteer.cy.jsx: 