### PR TITLE
Feature/update to production URL's

### DIFF
--- a/.github/workflows/backend.yml
+++ b/.github/workflows/backend.yml
@@ -25,7 +25,7 @@ jobs:
 
       - run: pytest core/tests/
         env:
-          SECRET_KEY: ci-secret-key-not-used-in-prod
+          DJANGO_SECRET_KEY: ci-secret-key-not-used-in-prod
           # GOOGLE_CLIENT_ID / SECRET intentionally omitted — Google Calendar calls are mocked in tests
           GOOGLE_CLIENT_ID: test-client-id
           GOOGLE_CLIENT_SECRET: test-client-secret

--- a/Backend/.env.development
+++ b/Backend/.env.development
@@ -1,0 +1,2 @@
+FRONTEND_URL=http://localhost:5173
+VITE_API_URL=http://localhost:8000

--- a/Backend/.env.example
+++ b/Backend/.env.example
@@ -1,2 +1,3 @@
 GOOGLE_CLIENT_ID=[ask system owner for values]
 GOOGLE_CLIENT_SECRET=[ask system owner for values]
+DJANGO_SECRET_KEY=""

--- a/Backend/.env.production
+++ b/Backend/.env.production
@@ -1,0 +1,2 @@
+FRONTEND_URL=https://pairscheduler-frontend.hosting.codeyourfuture.io
+VITE_API_URL=https://pairscheduler-backend.hosting.codeyourfuture.io

--- a/Backend/booking_system/settings.py
+++ b/Backend/booking_system/settings.py
@@ -34,13 +34,13 @@ GOOGLE_OAUTH2_CLIENT_SECRET = env("GOOGLE_CLIENT_SECRET")
 
 
 # SECURITY WARNING: keep the secret key used in production secret!
-SECRET_KEY = "django-insecure-(#1c#^ypty_2-2!3g^uu9p@z0=#2+7nv8qz#swf@yg&okj0ld1"
+SECRET_KEY = os.environ.get("DJANGO_SECRET_KEY")
 
 # SECURITY WARNING: don't run with debug turned on in production!
 DEBUG = DJANGO_ENV != "production"
 
 ALLOWED_HOSTS = [
-    "pairscheduler-backend.hosting.codeyourfuture.io",  # production backend
+    "pairscheduler-backend.hosting.codeyourfuture.io",
     "localhost",
     "127.0.0.1",
 ]
@@ -256,6 +256,3 @@ CSRF_TRUSTED_ORIGINS = [
     "http://127.0.0.1:5174",
     "https://pairscheduler-frontend.hosting.codeyourfuture.io",
 ]
-
-print("DJANGO_ENV:", DJANGO_ENV)
-print("FRONTEND_URL loaded:", FRONTEND_URL)

--- a/Backend/booking_system/settings.py
+++ b/Backend/booking_system/settings.py
@@ -34,7 +34,7 @@ GOOGLE_OAUTH2_CLIENT_SECRET = env("GOOGLE_CLIENT_SECRET")
 
 
 # SECURITY WARNING: keep the secret key used in production secret!
-SECRET_KEY = os.environ.get("DJANGO_SECRET_KEY")
+SECRET_KEY = env("DJANGO_SECRET_KEY")
 
 # SECURITY WARNING: don't run with debug turned on in production!
 DEBUG = DJANGO_ENV != "production"

--- a/Backend/booking_system/settings.py
+++ b/Backend/booking_system/settings.py
@@ -18,27 +18,32 @@ import os
 BASE_DIR = Path(__file__).resolve().parent.parent
 # This tells Django to read  .env file so  Google credentials become available.
 env = environ.Env()
+
+# Always load secrets
 environ.Env.read_env(os.path.join(BASE_DIR, ".env"))
 
-# Google OAuth2 credentials for manual login flow
-# These are read from the .env file to avoid exposing secrets in code
+# Then overlay environment-specific URLs
+DJANGO_ENV = os.getenv("DJANGO_ENV", "development")
+env_file = ".env.production" if DJANGO_ENV == "production" else ".env.development"
+environ.Env.read_env(os.path.join(BASE_DIR, env_file))
+
+FRONTEND_URL = env("FRONTEND_URL")
+BASE_API_URL = env("VITE_API_URL")
 GOOGLE_OAUTH2_CLIENT_ID = env("GOOGLE_CLIENT_ID")
 GOOGLE_OAUTH2_CLIENT_SECRET = env("GOOGLE_CLIENT_SECRET")
 
-# Base URL of the backend API
-# Used to build redirect URIs for OAuth2 login flow
-BASE_API_URL = "http://localhost:8000"
-
-# Quick-start development settings - unsuitable for production
-# See https://docs.djangoproject.com/en/6.0/howto/deployment/checklist/
 
 # SECURITY WARNING: keep the secret key used in production secret!
 SECRET_KEY = "django-insecure-(#1c#^ypty_2-2!3g^uu9p@z0=#2+7nv8qz#swf@yg&okj0ld1"
 
 # SECURITY WARNING: don't run with debug turned on in production!
-DEBUG = True
+DEBUG = DJANGO_ENV != "production"
 
-ALLOWED_HOSTS = []
+ALLOWED_HOSTS = [
+    "pairscheduler-backend.hosting.codeyourfuture.io",  # production backend
+    "localhost",
+    "127.0.0.1",
+]
 
 
 # Application definition
@@ -98,11 +103,12 @@ SOCIALACCOUNT_PROVIDERS = {
     }
 }
 
-# After Google login => user goes to your frontend
-LOGIN_REDIRECT_URL = "http://localhost:5173/"  # used by Django’s built‑in auth
-ACCOUNT_LOGIN_REDIRECT_URL = "http://localhost:5173/"  # used by allauth (Google login)
-LOGOUT_REDIRECT_URL = "http://localhost:5173/"
-ACCOUNT_LOGOUT_REDIRECT_URL = "http://localhost:5173/"
+LOGIN_REDIRECT_URL = f"{FRONTEND_URL}/"
+ACCOUNT_LOGIN_REDIRECT_URL = f"{FRONTEND_URL}/"
+LOGOUT_REDIRECT_URL = f"{FRONTEND_URL}/"
+ACCOUNT_LOGOUT_REDIRECT_URL = f"{FRONTEND_URL}/"
+
+
 # This makes sure Google login actually fills the email in the user record.
 SOCIALACCOUNT_QUERY_EMAIL = True
 ACCOUNT_EMAIL_REQUIRED = True
@@ -208,7 +214,7 @@ CORS_ALLOWED_ORIGINS = [
     "http://127.0.0.1:5173",
     "http://localhost:5174",
     "http://127.0.0.1:5174",
-    "http://localhost:3000",
+    "https://pairscheduler-frontend.hosting.codeyourfuture.io",  # production frontend
 ]
 CORS_ALLOW_CREDENTIALS = True
 
@@ -248,5 +254,8 @@ CSRF_TRUSTED_ORIGINS = [
     "http://127.0.0.1:5173",
     "http://localhost:5174",
     "http://127.0.0.1:5174",
-    "http://localhost:3000",
+    "https://pairscheduler-frontend.hosting.codeyourfuture.io",
 ]
+
+print("DJANGO_ENV:", DJANGO_ENV)
+print("FRONTEND_URL loaded:", FRONTEND_URL)

--- a/Frontend/.env.development
+++ b/Frontend/.env.development
@@ -1,0 +1,2 @@
+VITE_API_URL=http://localhost:8000
+

--- a/Frontend/.env.production
+++ b/Frontend/.env.production
@@ -1,0 +1,1 @@
+VITE_API_URL=https://pairscheduler-backend.hosting.codeyourfuture.io

--- a/Frontend/src/api/axiosClient.js
+++ b/Frontend/src/api/axiosClient.js
@@ -1,8 +1,9 @@
 import axios from "axios";
 import { getCSRFToken } from "../utilities/csrf";
 
+const BASE_URL = import.meta.env.VITE_API_URL;
 const api = axios.create({
-  baseURL: "http://localhost:8000",
+  baseURL: BASE_URL,
   withCredentials: true,
 });
 


### PR DESCRIPTION
This PR  Introduces environment‑specific configuration using CYF domain URLs for both frontend and backend, replacing hardcoded localhost values.

**Testing**  

Verified by exporting DJANGO_ENV=production locally and running `python manage.py runserver.` The console output confirmed .env.production was loaded and FRONTEND_URL resolved to the CYF domain. To reproduce:

1. Run `export DJANGO_ENV=production ` your backend virtual environment.
2. Start the server with `python manage.py runserver`
3. Check logs for DJANGO_ENV: production and FRONTEND_URL loaded: https://pairscheduler-frontend.hosting.codeyourfuture.io

Additional Notes  
During setup we faced an issue with our Google Cloud Console project which required enabling 2‑factor authentication. This was resolved by configuring the Google Authenticator app to secure project access.