### PR TITLE
Available slots endpoint for calendar frontend JSON response

### DIFF
--- a/Backend/core/serializers/available_slot_serializer.py
+++ b/Backend/core/serializers/available_slot_serializer.py
@@ -3,6 +3,7 @@ from rest_framework import serializers
 class AvailableSlotSerializer(serializers.Serializer):
     slot_rule_id = serializers.IntegerField()
     start_time = serializers.DateTimeField()
+    end_time = serializers.DateTimeField()
     volunteer_id = serializers.IntegerField()
     name = serializers.CharField()
     img = serializers.CharField()

--- a/Backend/core/serializers/available_slot_serializer.py
+++ b/Backend/core/serializers/available_slot_serializer.py
@@ -1,0 +1,8 @@
+from rest_framework import serializers
+
+class AvailableSlotSerializer(serializers.Serializer):
+    slot_rule_id = serializers.IntegerField()
+    start_time = serializers.DateTimeField()
+    volunteer_id = serializers.IntegerField()
+    name = serializers.CharField()
+    img = serializers.CharField()

--- a/Backend/core/services/available_slots.py
+++ b/Backend/core/services/available_slots.py
@@ -25,7 +25,7 @@ def build_available_slots(rules, beginning_of_booking_window):
                     group=rule.group,
                     start_time=start_time,
                     end_time=start_time + timedelta(hours=1),
-                    name=rule.volunteer.get_full_name(),
+                    name=rule.volunteer.get_full_name() or rule.volunteer.get_username(),
                     img="/public/placeholder.png",
                 )
             )

--- a/Backend/core/services/available_slots.py
+++ b/Backend/core/services/available_slots.py
@@ -25,7 +25,7 @@ def build_available_slots(rules, beginning_of_booking_window):
                     group=rule.group,
                     start_time=start_time,
                     end_time=start_time + timedelta(hours=1),
-                    name=rule.volunteer.get_full_name() or f"{rule.volunteer.first_name} {rule.volunteer.last_name}".strip() or rule.volunteer.username,
+                    name=rule.volunteer.get_full_name(),
                     img="/public/placeholder.png",
                 )
             )

--- a/Backend/core/services/available_slots.py
+++ b/Backend/core/services/available_slots.py
@@ -9,6 +9,8 @@ class AvailableSlot:
     start_time: datetime
     end_time: datetime
     group: Optional[str]
+    name:str
+    img:Optional[str]
 
 def build_available_slots(rules, beginning_of_booking_window):
     slots = []
@@ -23,6 +25,8 @@ def build_available_slots(rules, beginning_of_booking_window):
                     group=rule.group,
                     start_time=start_time,
                     end_time=start_time + timedelta(hours=1),
+                    name=rule.volunteer.get_full_name() or f"{rule.volunteer.first_name} {rule.volunteer.last_name}".strip() or rule.volunteer.username,
+                    img="/public/placeholder.png",
                 )
             )
     return slots

--- a/Backend/core/tests/test_available_slots_service.py
+++ b/Backend/core/tests/test_available_slots_service.py
@@ -10,7 +10,7 @@ NOW = timezone.now()
 FUTURE = timezone.now() + timedelta(days=1)
 
 def make_slot_rule(
-        volunteer_id=1,
+    volunteer_id=1,
     start_time=None,
     repeat_until=None,
     rule_id=1,

--- a/Backend/core/tests/test_available_slots_service.py
+++ b/Backend/core/tests/test_available_slots_service.py
@@ -3,19 +3,34 @@ from datetime import timedelta
 from unittest.mock import patch
 from django.utils import timezone
 
-from core.models import SlotRule
+from core.models import SlotRule, User
 from core.services.available_slots import build_available_slots, exclude_booked_slots
 
 NOW = timezone.now()
 FUTURE = timezone.now() + timedelta(days=1)
 
-def make_slot_rule(volunteer_id=1, start_time=None, repeat_until=None, rule_id=1, group="itd"):
+def make_slot_rule(
+        volunteer_id=1,
+    start_time=None,
+    repeat_until=None,
+    rule_id=1,
+    group="itd",
+    first_name="Duncan",
+    last_name="Parkinson",
+    username="duncan",
+):
     rule = SlotRule()
     rule.id = rule_id
     rule.start_time = start_time or FUTURE
     rule.repeat_until = repeat_until
     rule.volunteer_id=volunteer_id
     rule.group = group
+    rule.volunteer = User(
+        id=volunteer_id,
+        username=username,
+        first_name=first_name,
+        last_name=last_name,
+    )
     return rule
 
 def test_one_off_slot(): 

--- a/Backend/core/tests/test_available_slots_view.py
+++ b/Backend/core/tests/test_available_slots_view.py
@@ -150,10 +150,12 @@ def test_slots_returned_includes_name_and_img():
     volunteer.save()
 
     SlotRule.objects.create(volunteer=volunteer, start_time=FUTURE, group="itd")
-
+    
     response = auth_client(trainee).get(URL)
+    slot = response.data[0]
 
     assert response.status_code == 200
     assert len(response.data) == 1
     assert response.data[0]["name"] == "Duncan Parkinson"
     assert response.data[0]["img"] == "/public/placeholder.png"
+    assert slot["end_time"] > slot["start_time"]    

--- a/Backend/core/tests/test_available_slots_view.py
+++ b/Backend/core/tests/test_available_slots_view.py
@@ -46,7 +46,6 @@ def test_slots_returned():
     assert response.status_code == 200
     assert len(response.data) == 1
     assert response.data[0]["volunteer_id"] == volunteer.id
-    assert response.data[0]["group"] == "itd"
 
 @pytest.mark.django_db
 def test_filter_by_volunteer():
@@ -141,3 +140,20 @@ def test_filter_by_host_role_admin():
     assert response.status_code == 200
     assert len(response.data) == 1
     assert response.data[0]["volunteer_id"] == admin_host.id
+
+@pytest.mark.django_db
+def test_slots_returned_includes_name_and_img():
+    trainee = make_user("trainee", group="itd")
+    volunteer = make_user("volunteer")
+    volunteer.first_name = "Duncan"
+    volunteer.last_name = "Parkinson"
+    volunteer.save()
+
+    SlotRule.objects.create(volunteer=volunteer, start_time=FUTURE, group="itd")
+
+    response = auth_client(trainee).get(URL)
+
+    assert response.status_code == 200
+    assert len(response.data) == 1
+    assert response.data[0]["name"] == "Duncan Parkinson"
+    assert response.data[0]["img"] == "/public/placeholder.png"

--- a/Backend/core/views.py
+++ b/Backend/core/views.py
@@ -25,6 +25,7 @@ from core.services.available_slots import build_available_slots, exclude_booked_
 from .user_serializers import UserSerializer
 from .serializers.booking_serializer import BookingSerializer
 from .serializers.slot_rule_serializer import SlotRuleSerializer
+from .serializers.available_slot_serializer import AvailableSlotSerializer
 
 
 class CreateMeetingView(APIView):
@@ -134,7 +135,8 @@ class AvailableSlotsView(APIView):
         
         slots = exclude_booked_slots(slots, booked_pairs)
 
-        return Response([dataclasses.asdict(slot) for slot in slots])
+        serializer = AvailableSlotSerializer(slots, many=True)
+        return Response(serializer.data)
    
 
 class SlotRuleCreateView(generics.CreateAPIView):


### PR DESCRIPTION
This PR refactors the available slots endpoint to align with current agreement returning to frontend JSON response to render in the calendar.

**Changes included**

- Refactor available_slots including name and img.
- Add serializer for available slots frontend response.
- Refactor AvailableSlotsView with serialize API response
- Refactor service test including user name.
- Update view tests available slots including name and img


**API response**

The endpoint now returns items in this format:

> [
>   {
>     "start_time": "2026-01-01T09:00:00Z",
>     "end_time": "2026-01-01T10:00:00Z",
>     "volunteer_id": 1,
>     "slot_rule_id": 1,
>     "name": "Duncan Parkinson",
>     "img": "/public/placeholder.png"
>   }
> ]

## Endpoint

**Use:**

`GET /api/available-slots/`


**Frontend usage**

If the frontend Axios client has baseURL = http://localhost:8000, use:

```
api.get("/api/available-slots/")
```

With filters:

```
api.get("/available-slots/", {
  params: {
    group: "itd",
    role: "volunteer",
  },
});
```

Notes
The img is fixed    ` "img": "/public/placeholder.png" `
Available query parameters: volunteer_id, group, role. 
Already booked slots are excluded before the response is returned
Testing

**Backend tests cover:**
- one-off slot generation
- recurring slot expansion
- booking window filtering
- booked slot exclusion
- endpoint filtering by group, volunteer, and role

Close #96 