### PR TITLE
fix: Remove commented-out Google Calendar credentials from backend tests

### DIFF
--- a/.github/workflows/backend.yml
+++ b/.github/workflows/backend.yml
@@ -26,6 +26,5 @@ jobs:
       - run: pytest core/tests/
         env:
           DJANGO_SECRET_KEY: ci-secret-key-not-used-in-prod
-          # GOOGLE_CLIENT_ID / SECRET intentionally omitted — Google Calendar calls are mocked in tests
           GOOGLE_CLIENT_ID: test-client-id
           GOOGLE_CLIENT_SECRET: test-client-secret


### PR DESCRIPTION
fix: Remove commented-out Google Calendar credentials from backend tests

https://github.com/SaraTahir28/Pair-Scheduling-APP/blob/46f9b47f9c033e11a7c3d40b9007f4e3705c8d27/.github/workflows/backend.yml#L29

This comment was removed because it is outdated now that we've included these variables.

Close #115 