### PR TITLE
fix-booking form updated with agenda

### DIFF
--- a/Frontend/cypress/e2e/Integration-Trainee.cy.jsx
+++ b/Frontend/cypress/e2e/Integration-Trainee.cy.jsx
@@ -23,7 +23,9 @@ describe("Trainee booking flow", () => {
 		cy.get(".cal-day-available").first().click();
 		cy.get(".timeslot-group-div button").first().click();
 
-		cy.get("input.form-input").first().clear().type("Kaska Test");
+		cy.get("textarea.form-input").type(
+			"I'd like to discuss React state management."
+		);
 		cy.get("button").contains("Book meeting").click();
 
 		cy.wait("@postBooking");

--- a/Frontend/cypress/tests/BookingForm.cy.jsx
+++ b/Frontend/cypress/tests/BookingForm.cy.jsx
@@ -8,7 +8,7 @@ describe("BookingForm Component tests", () => {
 
 		cy.get("label.form-label").should(
 			"contain",
-			"Okay Kaska, what would you like to discuss?"
+			"Okay Kaska Test, what would you like to discuss?"
 		);
 	});
 
@@ -25,6 +25,7 @@ describe("BookingForm Component tests", () => {
 
 		cy.get("textarea.form-input").type("Too short");
 		cy.get("button").contains("Book meeting").click();
+		cy.get("@testedSubmit").should("not.have.been.called");
 	});
 
 	it("allows typing in the agenda field", () => {

--- a/Frontend/cypress/tests/BookingForm.cy.jsx
+++ b/Frontend/cypress/tests/BookingForm.cy.jsx
@@ -1,55 +1,42 @@
 import BookingForm from "../../src/components/groups/BookingForm";
 
 describe("BookingForm Component tests", () => {
-	it("shows the tested name and email and verifies email is readOnly", () => {
-		const testedTrainee = { name: "Test Trainee", email: "trainee@test.com" };
+	it("shows the name in label greting", () => {
+		const testedTrainee = { name: "Kaska Test", email: "kaska@test.com" };
 
 		cy.mount(<BookingForm trainee={testedTrainee} whenFormSubmit={() => {}} />);
 
-		cy.get("input.form-input").first().should("have.value", "Test Trainee");
-
-		cy.get("input.form-input-disabled")
-			.should("have.value", "trainee@test.com")
-			.and("have.attr", "readonly");
+		cy.get("label.form-label").should(
+			"contain",
+			"Okay Kaska, what would you like to discuss?"
+		);
 	});
 
-	it("triggers alert when the name is too short", () => {
-		const testedTrainee = { name: "T", email: "trainee@test.com" };
-
-		cy.mount(<BookingForm trainee={testedTrainee} whenFormSubmit={() => {}} />);
-
-		cy.on("window:alert", (text) => {
-			expect(text).to.contains("Name should be between 2 and 50 chars.");
-		});
-
-		cy.get("button").contains("Book meeting").click();
-	});
-
-	it("cleans name by removing numbers and symbols on submit", () => {
+	it("sends alert when agenda is too short", () => {
 		const testedSubmit = cy.stub().as("testedSubmit");
-		const testedTrainee = { name: "", email: "trainee@test.com" };
+		const testedTrainee = { name: "Kaska", email: "kaska@test.com" };
 
 		cy.mount(
 			<BookingForm trainee={testedTrainee} whenFormSubmit={testedSubmit} />
 		);
-
-		cy.get("input.form-input").first().type("Kaska123?");
-		cy.get("button").contains("Book meeting").click();
-
-		cy.get("@testedSubmit").should("have.been.calledWith", {
-			traineeName: "Kaska",
-			traineeEmail: "trainee@test.com",
+		cy.on("window:alert", (text) => {
+			expect(text).to.contains("Agenda should be between 10 and 500 chars.");
 		});
+
+		cy.get("textarea.form-input").type("Too short");
+		cy.get("button").contains("Book meeting").click();
 	});
 
-	it("allows typing in the name input", () => {
-		const testedTrainee = { name: "", email: "trainee@test.com" };
+	it("allows typing in the agenda field", () => {
+		const testedTrainee = { name: "Kaska", email: "kaska@test.com" };
 
 		cy.mount(<BookingForm trainee={testedTrainee} whenFormSubmit={() => {}} />);
 
-		cy.get("input.form-input")
-			.first()
-			.type("New Name")
-			.should("have.value", "New Name");
+		cy.get("textarea.form-input")
+			.type("I want to learn about passing props between components in React")
+			.should(
+				"have.value",
+				"I want to learn about passing props between components in React"
+			);
 	});
 });

--- a/Frontend/src/components/groups/BookingForm.jsx
+++ b/Frontend/src/components/groups/BookingForm.jsx
@@ -2,59 +2,45 @@ import React, { useState } from "react";
 import { ActionBtn } from "../elements/Button";
 
 const BookingForm = ({ whenFormSubmit, trainee }) => {
-	//set up local state that will be passed to app
-	const [name, setName] = useState(trainee?.name || "");
-	// Email is now derived directly from props to avoid stale state
-	const currentEmail = trainee?.email || "";
+	const [firstName] = useState(
+		trainee?.name
+			? trainee?.name.split(" ")[0].charAt(0).toUpperCase() +
+					trainee.name.split(" ")[0].slice(1)
+			: ""
+	);
+
+	const [agenda, setAgenda] = useState("");
 	const checkInputsValid = (e) => {
-		//stop reload
 		e.preventDefault();
-		const cleanName = name.trim().replace(/[^a-zA-Z\s]/g, "");
+		const cleanAgenda = agenda.trim();
 
-		if (cleanName.length < 2 || cleanName.length > 50) {
-			alert("Name should be between 2 and 50 chars.");
-			return;
-		}
-
-		if (!currentEmail.includes("@") || !currentEmail.includes(".")) {
-			alert("Please enter a valid email.");
+		if (cleanAgenda.length < 10 || cleanAgenda.length > 500) {
+			alert("Agenda should be between 10 and 500 chars.");
 			return;
 		}
 
 		whenFormSubmit({
-			traineeName: cleanName,
-			traineeEmail: currentEmail,
+			agenda: cleanAgenda,
 		});
 	};
 
-	{
-		/* onChange grabs keystroke and saves it to state onChange={(e) => setName(e.target.value)} */
-	}
 	return (
 		<div className="booking-form-container">
-			<h2 className="form-title">Enter your details</h2>
+			<h2 className="form-title">Your session details</h2>
 			<form>
 				<div className="form-input-group">
-					<label className="form-label">Name</label>
-					<input
+					<label className="form-label">
+						Okay {firstName}, what would you like to discuss?
+					</label>
+					<textarea
 						className="form-input"
-						type="text"
-						placeholder="Enter your name"
-						value={name}
-						onChange={(e) => setName(e.target.value)}
+						placeholder="Share the specific topic you would like to cover."
+						value={agenda}
+						rows="6"
+						onChange={(e) => setAgenda(e.target.value)}
 					/>
 				</div>
 
-				<div className="form-input-group">
-					<label className="form-label">Email</label>
-					<input
-						className="form-input form-input-disabled"
-						type="email"
-						label="Email"
-						value={currentEmail}
-						readOnly
-					/>
-				</div>
 				<br></br>
 				<ActionBtn additionalBtnClass="btn-primary" onClick={checkInputsValid}>
 					Book meeting

--- a/Frontend/src/components/groups/BookingForm.jsx
+++ b/Frontend/src/components/groups/BookingForm.jsx
@@ -2,12 +2,7 @@ import React, { useState } from "react";
 import { ActionBtn } from "../elements/Button";
 
 const BookingForm = ({ whenFormSubmit, trainee }) => {
-	const [firstName] = useState(
-		trainee?.name
-			? trainee?.name.split(" ")[0].charAt(0).toUpperCase() +
-					trainee.name.split(" ")[0].slice(1)
-			: ""
-	);
+	const name = trainee?.name;
 
 	const [agenda, setAgenda] = useState("");
 	const checkInputsValid = (e) => {
@@ -30,7 +25,9 @@ const BookingForm = ({ whenFormSubmit, trainee }) => {
 			<form>
 				<div className="form-input-group">
 					<label className="form-label">
-						Okay {firstName}, what would you like to discuss?
+						{name
+							? `Okay ${name}, what would you like to discuss?`
+							: `What would you like to discuss?`}
 					</label>
 					<textarea
 						className="form-input"
@@ -41,7 +38,6 @@ const BookingForm = ({ whenFormSubmit, trainee }) => {
 					/>
 				</div>
 
-				<br></br>
 				<ActionBtn additionalBtnClass="btn-primary" onClick={checkInputsValid}>
 					Book meeting
 				</ActionBtn>

--- a/Frontend/src/index.css
+++ b/Frontend/src/index.css
@@ -192,14 +192,11 @@
 		@apply gap-2 flex flex-col;
 	}
 	.form-label {
-		@apply text-[11px] font-bold text-muted uppercase tracking-wider;
+		@apply text-[16px] font-bold text-muted uppercase tracking-wider;
 	}
 	.form-input {
 		@apply border border-black/10 rounded-xl p-3 w-full max-w-[400px] outline-none transition-all bg-gray-50/50;
 		@apply focus:border-brand-blue focus:ring-1 focus:ring-brand-blue/10;
-	}
-	.form-input-disabled {
-		@apply bg-gray-100 text-muted border-transparent cursor-not-allowed;
 	}
 
 	/* here will add confirmation styling */

--- a/Frontend/src/index.css
+++ b/Frontend/src/index.css
@@ -189,7 +189,7 @@
 		@apply text-xl font-bold text-dark mb-6;
 	}
 	.form-input-group {
-		@apply gap-2 flex flex-col;
+		@apply gap-2 flex flex-col mb-2;
 	}
 	.form-label {
 		@apply text-[16px] font-bold text-muted uppercase tracking-wider;


### PR DESCRIPTION
This PR updates the trainee booking form to provide a meeting agenda while removing redundant trainee fields (which are now handled via auth).

Changes
BookingForm.jsx:
Swapped traineeName and traineeEmail input fields for a greeting using the trainee.name prop.
Added an Agenda textarea with basic validation.
Updated CSS to remove the redundant disabled input.

Note: Even though the email field is no longer required in the Booking Form, I kept the email within the tests to maintain the user object consistent.