### PR TITLE
Feature/ connecting frontend create slot to api/slot-rules

### DIFF
--- a/Frontend/cypress/e2e/Integration-VolunteerOnboarding.cy.jsx
+++ b/Frontend/cypress/e2e/Integration-VolunteerOnboarding.cy.jsx
@@ -66,6 +66,9 @@ describe("Volunteer flow", () => {
 		cy.get(".form-checkbox").check();
 		cy.get(".form-checkbox").should("be.checked");
 
+		cy.get('input[type="date"]').eq(1).clear().type("2026-06-15");
+		cy.get('input[type="date"]').eq(1).should("have.value", "2026-06-15");
+
 		cy.contains("Select date").should("not.exist");
 		cy.contains("label", "Starting on").should("be.visible");
 		cy.contains("This session will repeat every Friday").should("be.visible");

--- a/Frontend/src/components/groups/AddingSlotsBasket.jsx
+++ b/Frontend/src/components/groups/AddingSlotsBasket.jsx
@@ -37,6 +37,9 @@ const AddingSlotsBasket = ({ addedSlots, removeSlot, saveAll }) => {
 										.split("T")[0]
 										.split("-")
 										.reverse()
+										.join("-")} until ${entry.repeat_until
+										.split("-")
+										.reverse()
 										.join("-")})`}
 								</span>
 							)}

--- a/Frontend/src/components/groups/VolunteerAvailabilityForm.jsx
+++ b/Frontend/src/components/groups/VolunteerAvailabilityForm.jsx
@@ -16,13 +16,12 @@ const VolunteerAvailabilityForm = ({
 		});
 	};
 
-	//this is with repeated date initially set to off
 	const [isRecurring, setIsRecurring] = useState(false);
 	const [specificDate, setSpecificDate] = useState(
 		new Date().toISOString().split("T")[0]
 	);
 	const [startTime, setStartTime] = useState("09:00");
-	// const [endTime, setEndTime] = useState(""); //TODO nice to haves
+	const [repeatUntil, setRepeatUntil] = useState("");
 
 	const checkInputsValid = (e) => {
 		e.preventDefault();
@@ -37,28 +36,21 @@ const VolunteerAvailabilityForm = ({
 			return;
 		}
 
-		const timeWithDate = `${specificDate}T${startTime}:00`;
+		if (isRecurring && !repeatUntil) {
+			alert("Please select a 'Repeat until' date.");
+			return;
+		}
 
-		// TODO - nice to haves
-		// for now no tim limit
-		// const futureDate = new Date();
-		// futureDate.setMonth(today.getMonth() + 3);
-		// const endDateStr = isRecurring
-		// 	? futureDate.toISOString().split("T")[0]
-		// 	: startDateStr;
+		const timeWithDate = `${specificDate}T${startTime}:00Z`;
 
-		// build slotsObj
 		const slotsObj = {
-			volunteer_id: volunteerId,
+			volunteer: volunteerId,
 			regular: isRecurring,
 			weekday: isRecurring ? getDayName(specificDate) : null,
 			start_time: timeWithDate,
-			repeat_until: null,
-			// TODO repeat_until: isRecurring ? futureDate.toISOString() : null,
-			// endTime: endTime, // this is for future now no end
-			group: null,
+			repeat_until: isRecurring ? repeatUntil : null,
+			group: "all",
 		};
-		console.log("obj for db", slotsObj);
 		whenFormSubmit(slotsObj);
 
 		setStartTime("09:00");
@@ -87,7 +79,6 @@ const VolunteerAvailabilityForm = ({
 								className="form-input"
 								type="date"
 								disabled={mode === "view"}
-								//TODO admin view later and view selected availability
 								value={specificDate}
 								onChange={(e) => setSpecificDate(e.target.value)}
 							/>
@@ -108,6 +99,19 @@ const VolunteerAvailabilityForm = ({
 									}}
 								/>
 							</div>
+
+							<div className="form-input-group">
+								<label className="form-label">Repeat until</label>
+								<input
+									className="form-input"
+									type="date"
+									disabled={mode === "view"}
+									min={specificDate}
+									value={repeatUntil}
+									onChange={(e) => setRepeatUntil(e.target.value)}
+								/>
+							</div>
+
 							<div className="form-input-group">
 								<span>
 									This session will repeat every{" "}

--- a/Frontend/src/components/pages/VolunteerDash.jsx
+++ b/Frontend/src/components/pages/VolunteerDash.jsx
@@ -8,9 +8,9 @@ import VolunteerEditSession from "../groups/VolunteerEditSession";
 import VolunteerViewSession from "../groups/VolunteerViewSession";
 
 import VolunteerAvailabilityForm from "../groups/VolunteerAvailabilityForm";
-import { ActionBtn } from "../elements/Button";
 import { useAuth } from "../../AuthContext";
 import duncanImg from "../../assets/duncan.png";
+import api from "../../api/axiosClient";
 
 const VolunteerDash = () => {
 	const { id } = useParams();
@@ -36,12 +36,30 @@ const VolunteerDash = () => {
 
 	const sendVolunteerSlotsToDb = () => {
 		console.log("Ready to send to db", temporaryAddedSlotsStorage);
-		alert("Availability is saved.");
+		for (let i = 0; i < temporaryAddedSlotsStorage.length; i++) {
+			let slotWeAreOn = temporaryAddedSlotsStorage[i];
 
+			let objectToSendToBackend = {
+				volunteer: slotWeAreOn.volunteer,
+				start_time: slotWeAreOn.start_time,
+				repeat_until: slotWeAreOn.repeat_until,
+				group: "all",
+			};
+
+			api
+				.post("/api/slot-rules/", objectToSendToBackend)
+				.then(() => {
+					console.log("Slot zapisany w bazie!");
+					setHasUserSetAvailability(true);
+					setTemporaryAddedSlotsStorage([]);
+				})
+				.catch((error) => console.log("Error:", error));
+		}
+
+		alert("Availability is saved.");
 		setHasUserSetAvailability(true);
 	};
 
-	// grab all sessions for active user
 	const activeVolunteerSessions = allBookedSessionsForAllUsers.filter(
 		(session) => session.volunteerId === activeVolunteer.id
 	);
@@ -113,10 +131,8 @@ const VolunteerDash = () => {
 				/>
 			</div>
 			<div className="bookings-col">
-				{/* onboarding if slots are not selected - form shows */}
 				{!hasUserSetAvailability && (
 					<div className="">
-						{/* <h1 className="form-title">Welcome {activeVolunteer.name}!</h1> */}
 						<p className="">
 							Let's start by selecting your availability for 1:1 sessions.
 						</p>

--- a/Frontend/src/components/pages/VolunteerDash.jsx
+++ b/Frontend/src/components/pages/VolunteerDash.jsx
@@ -35,29 +35,24 @@ const VolunteerDash = () => {
 	};
 
 	const sendVolunteerSlotsToDb = () => {
-		console.log("Ready to send to db", temporaryAddedSlotsStorage);
-		for (let i = 0; i < temporaryAddedSlotsStorage.length; i++) {
-			let slotWeAreOn = temporaryAddedSlotsStorage[i];
-
-			let objectToSendToBackend = {
-				volunteer: slotWeAreOn.volunteer,
-				start_time: slotWeAreOn.start_time,
-				repeat_until: slotWeAreOn.repeat_until,
-				group: "all",
-			};
-
-			api
-				.post("/api/slot-rules/", objectToSendToBackend)
-				.then(() => {
-					console.log("Slot zapisany w bazie!");
-					setHasUserSetAvailability(true);
-					setTemporaryAddedSlotsStorage([]);
+		Promise.all(
+			temporaryAddedSlotsStorage.map((slot) =>
+				api.post("/api/slot-rules/", {
+					start_time: slot.start_time,
+					repeat_until: slot.repeat_until,
+					group: "all",
 				})
-				.catch((error) => console.log("Error:", error));
-		}
-
-		alert("Availability is saved.");
-		setHasUserSetAvailability(true);
+			)
+		)
+			.then(() => {
+				setHasUserSetAvailability(true);
+				setTemporaryAddedSlotsStorage([]);
+				alert("Availability is saved.");
+			})
+			.catch((error) => {
+				console.error("Error saving slots:", error);
+				alert("Failed to save availability. Please try again.");
+			});
 	};
 
 	const activeVolunteerSessions = allBookedSessionsForAllUsers.filter(


### PR DESCRIPTION
This PR connects the frontend to them to /api/slot-rules/. 

Changes
VolunteerDash.jsx matches the agreed contract: volunteer, start_time, repeat_until, and group.
Added a repeat_until date picker to the VolunteerAvailabilityForm for recurring slots.
Updated AddingSlotsBasket to display the end date for recurring rules.
Updated Cypress component integration test (volunteer_flow.cy.js) to add "Repeat until" field.

Testing
npx cypress open
select e2e Integration-VolunteerOnboarding.cy.jsx

Further Changes 
Promise.all: Replaced the for loop with Promise.all combined with .map() so the UI only updates after all slot creation requests have successfully resolved.
The slot data are passed directly into the api.post call instead of creating an object.
The alert and state updates (setHasUserSetAvailability) are set in the .then() block, so the user sees them only when data is received by the backend.
Volunteer is removed because the backend now identifies the volunteer via the active session/token.