### PR TITLE
Feature/session details display logged in user

### DIFF
--- a/Frontend/eslint.config.js
+++ b/Frontend/eslint.config.js
@@ -1,38 +1,39 @@
-import js from '@eslint/js'
-import globals from 'globals'
-import react from 'eslint-plugin-react'
-import reactHooks from 'eslint-plugin-react-hooks'
-import reactRefresh from 'eslint-plugin-react-refresh'
+import js from "@eslint/js";
+import globals from "globals";
+import react from "eslint-plugin-react";
+import reactHooks from "eslint-plugin-react-hooks";
+import reactRefresh from "eslint-plugin-react-refresh";
 
 export default [
-  { ignores: ['dist'] },
-  {
-    files: ['**/*.{js,jsx}'],
-    languageOptions: {
-      ecmaVersion: 2020,
-      globals: globals.browser,
-      parserOptions: {
-        ecmaVersion: 'latest',
-        ecmaFeatures: { jsx: true },
-        sourceType: 'module',
-      },
-    },
-    settings: { react: { version: '18.3' } },
-    plugins: {
-      react,
-      'react-hooks': reactHooks,
-      'react-refresh': reactRefresh,
-    },
-    rules: {
-      ...js.configs.recommended.rules,
-      ...react.configs.recommended.rules,
-      ...react.configs['jsx-runtime'].rules,
-      ...reactHooks.configs.recommended.rules,
-      'react/jsx-no-target-blank': 'off',
-      'react-refresh/only-export-components': [
-        'warn',
-        { allowConstantExport: true },
-      ],
-    },
-  },
-]
+	{ ignores: ["dist"] },
+	{
+		files: ["**/*.{js,jsx}"],
+		languageOptions: {
+			ecmaVersion: 2020,
+			globals: globals.browser,
+			parserOptions: {
+				ecmaVersion: "latest",
+				ecmaFeatures: { jsx: true },
+				sourceType: "module",
+			},
+		},
+		settings: { react: { version: "18.3" } },
+		plugins: {
+			react,
+			"react-hooks": reactHooks,
+			"react-refresh": reactRefresh,
+		},
+		rules: {
+			...js.configs.recommended.rules,
+			...react.configs.recommended.rules,
+			...react.configs["jsx-runtime"].rules,
+			...reactHooks.configs.recommended.rules,
+			"react/prop-types": "off",
+			"react/jsx-no-target-blank": "off",
+			"react-refresh/only-export-components": [
+				"warn",
+				{ allowConstantExport: true },
+			],
+		},
+	},
+];

--- a/Frontend/src/components/groups/SessionDetails.jsx
+++ b/Frontend/src/components/groups/SessionDetails.jsx
@@ -1,4 +1,3 @@
-/* eslint-disable react/prop-types */
 import { Clock, Video } from "lucide-react";
 import { useAuth } from "../../AuthContext";
 
@@ -39,7 +38,7 @@ const SessionDetails = ({
 		);
 	}
 
-	if (traineeView || !volunteerView) {
+	if (traineeView) {
 		return (
 			<>
 				<div className="session-details-div">
@@ -69,7 +68,7 @@ const SessionDetails = ({
 						</div>
 
 						<p>
-							Your session is with <br></br>
+							You are booking a session with <br />
 							<strong>{activeVolunteerProps.name}</strong>
 						</p>
 					</div>

--- a/Frontend/src/components/groups/SessionDetails.jsx
+++ b/Frontend/src/components/groups/SessionDetails.jsx
@@ -1,7 +1,15 @@
-import React from "react";
+/* eslint-disable react/prop-types */
 import { Clock, Video } from "lucide-react";
+import { useAuth } from "../../AuthContext";
 
-const SessionDetails = ({ activeVolunteerProps, volunteerView }) => {
+const SessionDetails = ({
+	activeVolunteerProps,
+	volunteerView,
+	traineeView,
+	onManageAvailabilityClick,
+}) => {
+	const { user } = useAuth();
+
 	if (volunteerView) {
 		return (
 			<div className="session-details-div">
@@ -9,50 +17,68 @@ const SessionDetails = ({ activeVolunteerProps, volunteerView }) => {
 				<div className="availableVolunteersDiv">
 					<div className="avatar-row">
 						<img
-							src={activeVolunteerProps.img}
+							src={user?.img || "/default-avatar.png"}
 							className="avatar"
 							alt="Profile"
 						/>
 					</div>
 					<p>
 						You are logged in as <br />
-						<strong>{activeVolunteerProps.name}</strong>
+						<strong>{user?.name || "Volunteer"}</strong>
 					</p>
+					{onManageAvailabilityClick && (
+						<button
+							className="btn-secondary mt-4"
+							onClick={onManageAvailabilityClick}
+						>
+							Manage my availability
+						</button>
+					)}
 				</div>
 			</div>
 		);
 	}
 
-	return (
-		<>
-			<div className="session-details-div">
-				<h1>Book 1:1 session</h1>
+	if (traineeView || !volunteerView) {
+		return (
+			<>
+				<div className="session-details-div">
+					<h1>Book 1:1 session</h1>
 
-				<div className="session-icon-text">
-					<div className="session-icon-text-line">
-						<Clock className="session-icon" />
-						<p>1 hour</p>
-					</div>
+					<div className="session-icon-text">
+						<div className="session-icon-text-line">
+							<Clock className="session-icon" />
+							<p>1 hour</p>
+						</div>
 
-					<div className="session-icon-text-line">
-						<Video className="session-icon" />
-						<p>Google Meet link provided upon confirmation.</p>
+						<div className="session-icon-text-line">
+							<Video className="session-icon" />
+							<p>Google Meet link provided upon confirmation.</p>
+						</div>
 					</div>
 				</div>
-			</div>
 
-			<div className="availableVolunteersDiv">
-				<div className="avatar-row">
-					<img src={activeVolunteerProps.img} className="avatar" />
-				</div>
+				{activeVolunteerProps && (
+					<div className="availableVolunteersDiv">
+						<div className="avatar-row">
+							<img
+								src={activeVolunteerProps.img}
+								className="avatar"
+								alt="profile avatar"
+							/>
+						</div>
 
-				<p>
-					Your session is with <br></br>
-					<strong>{activeVolunteerProps.name}</strong>
-				</p>
-			</div>
-		</>
-	);
+						<p>
+							Your session is with <br></br>
+							<strong>{activeVolunteerProps.name}</strong>
+						</p>
+					</div>
+				)}
+			</>
+		);
+	}
+
+	return null;
 };
 
 export default SessionDetails;

--- a/Frontend/src/components/pages/TraineeBookingFlow.jsx
+++ b/Frontend/src/components/pages/TraineeBookingFlow.jsx
@@ -10,177 +10,178 @@ import { BackBtn } from "../elements/Button";
 import { useAuth } from "../../AuthContext";
 
 const TraineeBookingFlow = () => {
-  const [allVolunteersData, setAllVolunteersData] = useState(null);
-  //TODO next PR show all slots from all volunteers
-  const [activeVolunteer, setActiveVolunteer] = useState(null);
+	const [allVolunteersData, setAllVolunteersData] = useState(null);
+	//TODO next PR show all slots from all volunteers
+	const [activeVolunteer, setActiveVolunteer] = useState(null);
 
-  const { selectedDate, selectedTime, status } = useParams();
-  const { user } = useAuth();
-  const navigate = useNavigate();
+	const { selectedDate, selectedTime, status } = useParams();
+	const { user } = useAuth();
+	const navigate = useNavigate();
 
-  useEffect(() => {
-    api
-      .get("/api/available-slots/")
-      .then((res) => {
-        setAllVolunteersData(res.data);
-        if (res.data && res.data.length > 0) {
-          setActiveVolunteer({
-            id: res.data[0].volunteer_id,
-            name: res.data[0].name,
-            img: res.data[0].img,
-          });
-        }
-      })
-      .catch((err) => console.log(err));
-  }, []);
+	useEffect(() => {
+		api
+			.get("/api/available-slots/")
+			.then((res) => {
+				setAllVolunteersData(res.data);
+				if (res.data && res.data.length > 0) {
+					setActiveVolunteer({
+						id: res.data[0].volunteer_id,
+						name: res.data[0].name,
+						img: res.data[0].img,
+					});
+				}
+			})
+			.catch((err) => console.log(err));
+	}, []);
 
-  if (allVolunteersData === null || activeVolunteer === null) {
-    return (
-      <div className="booking-box">
-        <h2>Loading volunteers...</h2>
-      </div>
-    );
-  }
+	if (allVolunteersData === null || activeVolunteer === null) {
+		return (
+			<div className="booking-box">
+				<h2>Loading volunteers...</h2>
+			</div>
+		);
+	}
 
-  if (allVolunteersData.length === 0) {
-    return (
-      <div className="booking-box">
-        <h2>No volunteers are available at this time.</h2>
-      </div>
-    );
-  }
+	if (allVolunteersData.length === 0) {
+		return (
+			<div className="booking-box">
+				<h2>No volunteers are available at this time.</h2>
+			</div>
+		);
+	}
 
-  const convertedAllVDataToFrontendFormat = {
-    availableDates: [],
-    availableTimes: [],
-  };
+	const convertedAllVDataToFrontendFormat = {
+		availableDates: [],
+		availableTimes: [],
+	};
 
-  if (allVolunteersData && allVolunteersData.length > 0) {
-    const activeVolunteerSlots = allVolunteersData.filter((slot) => {
-      return slot.volunteer_id === activeVolunteer.id;
-    });
+	if (allVolunteersData && allVolunteersData.length > 0) {
+		const activeVolunteerSlots = allVolunteersData.filter((slot) => {
+			return slot.volunteer_id === activeVolunteer.id;
+		});
 
-    for (let i = 0; i < activeVolunteerSlots.length; i++) {
-      //starting str one is "2026-03-20T09:00:00Z"
-      let slotWeAreOn = activeVolunteerSlots[i];
-      let convertedToString = slotWeAreOn.start_time; //TODO/question - converting to str if not a str from backend, is that ever possible?
-      let dateOnlyStr = convertedToString.split("T")[0];
-      let dateBitsArr = dateOnlyStr.split("-");
-      let dayString = dateBitsArr[2];
-      let dayNumber = Number(dayString);
+		for (let i = 0; i < activeVolunteerSlots.length; i++) {
+			//starting str one is "2026-03-20T09:00:00Z"
+			let slotWeAreOn = activeVolunteerSlots[i];
+			let convertedToString = slotWeAreOn.start_time; //TODO/question - converting to str if not a str from backend, is that ever possible?
+			let dateOnlyStr = convertedToString.split("T")[0];
+			let dateBitsArr = dateOnlyStr.split("-");
+			let dayString = dateBitsArr[2];
+			let dayNumber = Number(dayString);
 
-      if (
-        convertedAllVDataToFrontendFormat.availableDates.includes(dayNumber) ===
-        false
-      ) {
-        convertedAllVDataToFrontendFormat.availableDates.push(dayNumber);
-      }
-      if (selectedDate && convertedToString.includes(selectedDate)) {
-        let timeOnlyStr = convertedToString.split("T")[1];
-        let timeBitsArr = timeOnlyStr.split(":");
-        let timeInFormathhmm = timeBitsArr[0] + ":" + timeBitsArr[1];
-        convertedAllVDataToFrontendFormat.availableTimes.push(timeInFormathhmm);
-      }
-    }
-  }
+			if (
+				convertedAllVDataToFrontendFormat.availableDates.includes(dayNumber) ===
+				false
+			) {
+				convertedAllVDataToFrontendFormat.availableDates.push(dayNumber);
+			}
+			if (selectedDate && convertedToString.includes(selectedDate)) {
+				let timeOnlyStr = convertedToString.split("T")[1];
+				let timeBitsArr = timeOnlyStr.split(":");
+				let timeInFormathhmm = timeBitsArr[0] + ":" + timeBitsArr[1];
+				convertedAllVDataToFrontendFormat.availableTimes.push(timeInFormathhmm);
+			}
+		}
+	}
 
-  const selectedDateObj = selectedDate ? new Date(selectedDate) : null;
+	const selectedDateObj = selectedDate ? new Date(selectedDate) : null;
 
-  const updateUrlWithDate = (newDate) => {
-    const dateString = newDate.toLocaleDateString("en-CA");
-    navigate(`/trainee-booking/${dateString}`);
-  };
+	const updateUrlWithDate = (newDate) => {
+		const dateString = newDate.toLocaleDateString("en-CA");
+		navigate(`/trainee-booking/${dateString}`);
+	};
 
-  const updateUrlWithTime = (newTime) => {
-    navigate(`/trainee-booking/${selectedDate}/${newTime}`);
-  };
+	const updateUrlWithTime = (newTime) => {
+		navigate(`/trainee-booking/${selectedDate}/${newTime}`);
+	};
 
-  const handleGoBack = () => {
-    navigate(`/trainee-booking/${selectedDate}`);
-  };
+	const handleGoBack = () => {
+		navigate(`/trainee-booking/${selectedDate}`);
+	};
 
-  const isConfirmationPage = status === "confirmation";
+	const isConfirmationPage = status === "confirmation";
 
-  const createBookingDetailsObj = (bookingFormData) => {
-    const combinedDateAndTimeFromUrl = `${selectedDate}T${selectedTime}:00`;
-    const timeSlotForBackend = `${combinedDateAndTimeFromUrl}Z`;
+	const createBookingDetailsObj = (bookingFormData) => {
+		const combinedDateAndTimeFromUrl = `${selectedDate}T${selectedTime}:00`;
+		const timeSlotForBackend = `${combinedDateAndTimeFromUrl}Z`;
 
-    const bookingDetailsObj = {
-      volunteer_id: activeVolunteer.id,
-      slot_rule_id: 1, //TODO will be updated in the next PR
-      time_slot: timeSlotForBackend,
-      agenda: bookingFormData.agenda || "No agenda provided.",
-    };
-    api
-      .post("/api/create-meeting/", bookingDetailsObj)
-      .then(() => {
-        navigate(
-          `/trainee-booking/${selectedDate}/${selectedTime}/confirmation`
-        );
-      })
-      .catch((error) => console.log("Error:", error));
-  };
+		const bookingDetailsObj = {
+			volunteer_id: activeVolunteer.id,
+			slot_rule_id: 1, //TODO will be updated in the next PR
+			time_slot: timeSlotForBackend,
+			agenda: bookingFormData.agenda || "No agenda provided.",
+		};
+		api
+			.post("/api/create-meeting/", bookingDetailsObj)
+			.then(() => {
+				navigate(
+					`/trainee-booking/${selectedDate}/${selectedTime}/confirmation`
+				);
+			})
+			.catch((error) => console.log("Error:", error));
+	};
 
-  return (
-    <div className="booking-box">
-      {isConfirmationPage ? (
-        <div className="conf-page-div">
-          <BookingConfirmation
-            selectedDateObj={selectedDateObj}
-            selectedTime={selectedTime}
-            volunteerProps={activeVolunteer}
-          />
-        </div>
-      ) : (
-        <>
-          <div className="session-details-col">
-            {!isConfirmationPage && (
-              <SessionDetails
-                selectedDateProps={selectedDateObj}
-                activeVolunteerProps={activeVolunteer}
-              />
-            )}
-          </div>
+	return (
+		<div className="booking-box">
+			{isConfirmationPage ? (
+				<div className="conf-page-div">
+					<BookingConfirmation
+						selectedDateObj={selectedDateObj}
+						selectedTime={selectedTime}
+						volunteerProps={activeVolunteer}
+					/>
+				</div>
+			) : (
+				<>
+					<div className="session-details-col">
+						{!isConfirmationPage && (
+							<SessionDetails
+								selectedDateProps={selectedDateObj}
+								activeVolunteerProps={activeVolunteer}
+								traineeView={true}
+							/>
+						)}
+					</div>
 
-          {!selectedTime && (
-            <>
-              <div className="calendar-col">
-                <Calendar
-                  selectedDateProps={selectedDateObj}
-                  setSelectedDateProps={updateUrlWithDate}
-                  availableDates={
-                    convertedAllVDataToFrontendFormat.availableDates
-                  }
-                />
-              </div>
-              <div className="timeslot-col">
-                <TimeSlotGroup
-                  selectedDateProps={selectedDateObj}
-                  setSelectedTimeProps={updateUrlWithTime}
-                  availableTimes={
-                    convertedAllVDataToFrontendFormat.availableTimes
-                  }
-                />
-              </div>
-            </>
-          )}
+					{!selectedTime && (
+						<>
+							<div className="calendar-col">
+								<Calendar
+									selectedDateProps={selectedDateObj}
+									setSelectedDateProps={updateUrlWithDate}
+									availableDates={
+										convertedAllVDataToFrontendFormat.availableDates
+									}
+								/>
+							</div>
+							<div className="timeslot-col">
+								<TimeSlotGroup
+									selectedDateProps={selectedDateObj}
+									setSelectedTimeProps={updateUrlWithTime}
+									availableTimes={
+										convertedAllVDataToFrontendFormat.availableTimes
+									}
+								/>
+							</div>
+						</>
+					)}
 
-          {selectedTime && !isConfirmationPage && (
-            <div className="timeslot-col trainee-timeslot-width">
-              <div className="back-btn-div">
-                <BackBtn onClick={handleGoBack} />
-              </div>
-              <BookingForm
-                whenFormSubmit={createBookingDetailsObj}
-                trainee={user}
-                key={user?.email || "guest"}
-              />
-            </div>
-          )}
-        </>
-      )}
-    </div>
-  );
+					{selectedTime && !isConfirmationPage && (
+						<div className="timeslot-col trainee-timeslot-width">
+							<div className="back-btn-div">
+								<BackBtn onClick={handleGoBack} />
+							</div>
+							<BookingForm
+								whenFormSubmit={createBookingDetailsObj}
+								trainee={user}
+								key={user?.email || "guest"}
+							/>
+						</div>
+					)}
+				</>
+			)}
+		</div>
+	);
 };
 
 export default TraineeBookingFlow;


### PR DESCRIPTION
This PR updates the `SessionDetails` component to conditionally render different views for volunteers and trainees.

Changes
- Added `traineeView` to `SessionDetails`
- `SessionDetails` now renders:
  - volunteer view in `VolunteerDash`
  - trainee booking view in `TraineeBookingFlow`
- In `TraineeBookingFlow`, `SessionDetails` receives `traineeView={true}` (VolunteerDash is unchanged)

Testing
- Trainee flow:
  - `SessionDetails` displays booking information
  - Displays the currently selected volunteer from `activeVolunteerProps`
  - Shows volunteer default avatar and name

- Volunteer view:
  - `SessionDetails` displays logged-in user from `useAuth()`
  - Shows volunteer default avatar and name
  - Displays "Manage my availability" button to open the availability manager

Notes
- View selection is hardcoded at the page level:
  - `VolunteerDash` → `volunteerView={true}`
  - `TraineeBookingFlow` → `traineeView={true}`