### PR TITLE
Fix/separate SessionDetails for volunteer/trainee and fix timezone bug on trainee booking

### DIFF
--- a/Frontend/cypress/tests/SessionDetails.cy.jsx
+++ b/Frontend/cypress/tests/SessionDetails.cy.jsx
@@ -8,28 +8,10 @@ describe("SessionDetails Component tests", () => {
   };
 
   it("shows trainee view by default", () => {
-    cy.mount(
-      <SessionDetails
-        activeVolunteerProps={testedVolunteer}
-        volunteerView={false}
-      />
-    );
+    cy.mount(<SessionDetails activeVolunteerProps={testedVolunteer} />);
 
     cy.contains("Book 1:1 session").should("be.visible");
-    cy.contains("Your session is with").should("be.visible");
-    cy.contains("Duncan").should("be.visible");
-  });
-
-  it("shows volunteer view when volunteerView is true", () => {
-    cy.mount(
-      <SessionDetails
-        activeVolunteerProps={testedVolunteer}
-        volunteerView={true}
-      />
-    );
-
-    cy.contains("Welcome back").should("be.visible");
-    cy.contains("You are logged in as").should("be.visible");
+    cy.contains("You are booking a session with").should("be.visible");
     cy.contains("Duncan").should("be.visible");
   });
 });

--- a/Frontend/cypress/tests/TraineeBookingFlow.cy.jsx
+++ b/Frontend/cypress/tests/TraineeBookingFlow.cy.jsx
@@ -1,6 +1,7 @@
 import { MemoryRouter, Route, Routes } from "react-router-dom";
 import TraineeBookingFlow from "../../src/components/pages/TraineeBookingFlow";
 import { AuthProvider } from "../../src/AuthContext";
+import { formatLocalDate, formatLocalTime } from "../../src/utilities/dateTime";
 
 const mockUser = { id: 1, name: "Test Trainee", email: "trainee@test.com" };
 
@@ -69,7 +70,13 @@ describe("TraineeBookingFlow URL validation", () => {
     cy.get("[role='alert']").should("not.exist");
   });
 
-  it("submits the booking time as UTC", () => {
+  it("shows slots in local time and submits the original UTC", () => {
+    const advertisedUtc = "2026-07-01T09:00:00Z";
+    const slotStart = new Date(advertisedUtc);
+    const expectedLocalDate = formatLocalDate(slotStart);
+    const expectedLocalTime = formatLocalTime(slotStart);
+    console.log(expectedLocalDate, expectedLocalTime);
+
     cy.intercept("GET", "**/api/available-slots/", {
       statusCode: 200,
       body: [
@@ -78,8 +85,10 @@ describe("TraineeBookingFlow URL validation", () => {
           slot_rule_id: 1,
           name: "Test Volunteer",
           img: "",
-          start_time: "2026-04-01T09:00:00Z",
-          end_time: "2026-04-01T10:00:00Z",
+          start_time: advertisedUtc,
+          end_time: new Date(
+            slotStart.getTime() + 60 * 60 * 1000
+          ).toISOString(),
         },
       ],
     }).as("availableSlots");
@@ -89,15 +98,18 @@ describe("TraineeBookingFlow URL validation", () => {
       body: {},
     }).as("createMeeting");
 
-    mountAtRoute("/trainee-booking/2026-04-01/09:00/pending/1/1");
+    mountAtRoute(`/trainee-booking/${expectedLocalDate}`);
+    cy.wait("@availableSlots");
 
-    cy.get("textarea").type("discuss promises in javascript");
+    cy.contains(".btn-time-slot", expectedLocalTime)
+      .should("be.visible")
+      .click();
+
+    cy.get("textarea").type("discuss how bad date handling is in javascript");
     cy.contains("Book meeting").click();
-
-    const expected = new Date(2026, 3, 1, 9, 0).toISOString();
 
     cy.wait("@createMeeting")
       .its("request.body.time_slot")
-      .should("equal", expected);
+      .should("equal", slotStart.toISOString());
   });
 });

--- a/Frontend/cypress/tests/TraineeBookingFlow.cy.jsx
+++ b/Frontend/cypress/tests/TraineeBookingFlow.cy.jsx
@@ -75,7 +75,6 @@ describe("TraineeBookingFlow URL validation", () => {
     const slotStart = new Date(advertisedUtc);
     const expectedLocalDate = formatLocalDate(slotStart);
     const expectedLocalTime = formatLocalTime(slotStart);
-    console.log(expectedLocalDate, expectedLocalTime);
 
     cy.intercept("GET", "**/api/available-slots/", {
       statusCode: 200,

--- a/Frontend/src/components/groups/SessionDetails.jsx
+++ b/Frontend/src/components/groups/SessionDetails.jsx
@@ -1,7 +1,6 @@
 import { Clock, Video } from "lucide-react";
 
 const SessionDetails = ({ activeVolunteerProps }) => {
-
   return (
     <>
       <div className="session-details-div">

--- a/Frontend/src/components/groups/SessionDetails.jsx
+++ b/Frontend/src/components/groups/SessionDetails.jsx
@@ -1,40 +1,6 @@
-import React from "react";
 import { Clock, Video } from "lucide-react";
 
-const SessionDetails = ({
-  activeVolunteerProps,
-  volunteerView,
-  onManageAvailabilityClick,
-}) => {
-  if (volunteerView) {
-    return (
-      <div className="session-details-div">
-        <h1>Welcome back</h1>
-        <div className="availableVolunteersDiv">
-          <div className="avatar-row">
-            <img
-              src={activeVolunteerProps.img}
-              className="avatar"
-              alt="Profile"
-            />
-          </div>
-          <p>
-            You are logged in as <br />
-            <strong>{activeVolunteerProps.name}</strong>
-          </p>
-
-          {onManageAvailabilityClick && (
-            <button
-              className="btn-secondary"
-              onClick={onManageAvailabilityClick}
-            >
-              Manage my availability
-            </button>
-          )}
-        </div>
-      </div>
-    );
-  }
+const SessionDetails = ({ activeVolunteerProps }) => {
 
   return (
     <>
@@ -60,7 +26,7 @@ const SessionDetails = ({
         </div>
 
         <p>
-          Your session is with <br></br>
+          You are booking a session with <br></br>
           <strong>{activeVolunteerProps.name}</strong>
         </p>
       </div>

--- a/Frontend/src/components/groups/SessionDetailsVolunteer.jsx
+++ b/Frontend/src/components/groups/SessionDetailsVolunteer.jsx
@@ -1,14 +1,12 @@
 import { Calendar } from "lucide-react";
-import { useAuth } from "../../AuthContext";
 
-const VolunteerSessionDetails = ({ onManageAvailabilityClick }) => {
-	const { user } = useAuth() || {};
+const VolunteerSessionDetails = ({ onManageAvailabilityClick, user }) => {
 
 	return (
 		<div className="session-details-div">
 			<h1>Welcome</h1>
 
-			<div className="session-icon-text">
+			<div className="session-icon-div">
 				<div className="session-icon-text-line">
 					<p>You are logged in as</p>
 					<p>
@@ -19,7 +17,7 @@ const VolunteerSessionDetails = ({ onManageAvailabilityClick }) => {
 				<div className="avatar-row mt-2">
 					<img src={user?.img} className="avatar" alt="profile avatar" />
 				</div>
-				<div className="session-icon-text-line mt-4">
+				<div className="session-icon-text-line">
 					<p>You can view and manage your availability for 1:1 sessions.</p>
 				</div>
 				<div className="session-icon-text-line">

--- a/Frontend/src/components/groups/SessionDetailsVolunteer.jsx
+++ b/Frontend/src/components/groups/SessionDetailsVolunteer.jsx
@@ -1,0 +1,41 @@
+import { Calendar } from "lucide-react";
+import { useAuth } from "../../AuthContext";
+
+const VolunteerSessionDetails = ({ onManageAvailabilityClick }) => {
+	const { user } = useAuth() || {};
+
+	return (
+		<div className="session-details-div">
+			<h1>Welcome</h1>
+
+			<div className="session-icon-text">
+				<div className="session-icon-text-line">
+					<p>You are logged in as</p>
+					<p>
+						<strong>{user?.name || "a Volunteer"}</strong>
+					</p>
+				</div>
+
+				<div className="avatar-row mt-2">
+					<img src={user?.img} className="avatar" alt="profile avatar" />
+				</div>
+				<div className="session-icon-text-line mt-4">
+					<p>You can view and manage your availability for 1:1 sessions.</p>
+				</div>
+				<div className="session-icon-text-line">
+					{onManageAvailabilityClick && (
+						<button
+							className="btn-with-icon"
+							onClick={onManageAvailabilityClick}
+						>
+							<Calendar className="btn-icon" />
+							Manage my availability
+						</button>
+					)}
+				</div>
+			</div>
+		</div>
+	);
+};
+
+export default VolunteerSessionDetails;

--- a/Frontend/src/components/groups/SessionDetailsVolunteer.jsx
+++ b/Frontend/src/components/groups/SessionDetailsVolunteer.jsx
@@ -1,39 +1,38 @@
 import { Calendar } from "lucide-react";
 
 const VolunteerSessionDetails = ({ onManageAvailabilityClick, user }) => {
+  return (
+    <div className="session-details-div">
+      <h1>Welcome</h1>
 
-	return (
-		<div className="session-details-div">
-			<h1>Welcome</h1>
+      <div className="session-icon-div">
+        <div className="session-icon-text-line">
+          <p>You are logged in as</p>
+          <p>
+            <strong>{user?.name || "a Volunteer"}</strong>
+          </p>
+        </div>
 
-			<div className="session-icon-div">
-				<div className="session-icon-text-line">
-					<p>You are logged in as</p>
-					<p>
-						<strong>{user?.name || "a Volunteer"}</strong>
-					</p>
-				</div>
-
-				<div className="avatar-row mt-2">
-					<img src={user?.img} className="avatar" alt="profile avatar" />
-				</div>
-				<div className="session-icon-text-line">
-					<p>You can view and manage your availability for 1:1 sessions.</p>
-				</div>
-				<div className="session-icon-text-line">
-					{onManageAvailabilityClick && (
-						<button
-							className="btn-with-icon"
-							onClick={onManageAvailabilityClick}
-						>
-							<Calendar className="btn-icon" />
-							Manage my availability
-						</button>
-					)}
-				</div>
-			</div>
-		</div>
-	);
+        <div className="avatar-row mt-2">
+          <img src={user?.img} className="avatar" alt="profile avatar" />
+        </div>
+        <div className="session-icon-text-line">
+          <p>You can view and manage your availability for 1:1 sessions.</p>
+        </div>
+        <div className="session-icon-text-line">
+          {onManageAvailabilityClick && (
+            <button
+              className="btn-with-icon"
+              onClick={onManageAvailabilityClick}
+            >
+              <Calendar className="btn-icon" />
+              Manage my availability
+            </button>
+          )}
+        </div>
+      </div>
+    </div>
+  );
 };
 
 export default VolunteerSessionDetails;

--- a/Frontend/src/components/groups/VolunteerSelector.jsx
+++ b/Frontend/src/components/groups/VolunteerSelector.jsx
@@ -1,4 +1,3 @@
-
 const VolunteerSelector = ({
   volunteers,
   activeVolunteer,

--- a/Frontend/src/components/groups/VolunteerSelector.jsx
+++ b/Frontend/src/components/groups/VolunteerSelector.jsx
@@ -1,4 +1,3 @@
-import React from "react";
 
 const VolunteerSelector = ({
   volunteers,
@@ -19,10 +18,10 @@ const VolunteerSelector = ({
           }`}
           onClick={() => setActiveVolunteer(null)}
         >
-          All volunteers
+          View all volunteers
         </div>
 
-        {volunteers.map((volunteer) => (
+        {(activeVolunteer ? [activeVolunteer] : volunteers).map((volunteer) => (
           <div
             key={volunteer.id}
             className={`volunteer-card ${

--- a/Frontend/src/components/groups/VolunteerSelector.jsx
+++ b/Frontend/src/components/groups/VolunteerSelector.jsx
@@ -18,10 +18,10 @@ const VolunteerSelector = ({
           }`}
           onClick={() => setActiveVolunteer(null)}
         >
-          View all volunteers
+          View volunteers
         </div>
 
-        {(activeVolunteer ? [activeVolunteer] : volunteers).map((volunteer) => (
+        {volunteers.map((volunteer) => (
           <div
             key={volunteer.id}
             className={`volunteer-card ${

--- a/Frontend/src/components/pages/TraineeBookingFlow.jsx
+++ b/Frontend/src/components/pages/TraineeBookingFlow.jsx
@@ -15,7 +15,7 @@ import {
   parseLocalDate,
   parseLocalDateTime,
   formatLocalDate,
-  formatLocalTime
+  formatLocalTime,
 } from "../../utilities/dateTime";
 
 const TraineeBookingFlow = () => {
@@ -211,7 +211,9 @@ const TraineeBookingFlow = () => {
                 <>
                   <div className="session-details-div">
                     <h1>Book 1:1 session</h1>
-                    <p className="session-icon-text-line">Viewing availability from all volunteers</p>
+                    <p className="session-icon-text-line">
+                      Viewing availability from all volunteers
+                    </p>
                   </div>
                 </>
               ))}

--- a/Frontend/src/components/pages/TraineeBookingFlow.jsx
+++ b/Frontend/src/components/pages/TraineeBookingFlow.jsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from "react";
+import { useState, useEffect } from "react";
 import { useParams, useNavigate } from "react-router-dom";
 import SessionDetails from "../groups/SessionDetails";
 import VolunteerSelector from "../groups/VolunteerSelector";
@@ -209,7 +209,12 @@ const TraineeBookingFlow = () => {
                   activeVolunteerProps={activeVolunteer}
                 />
               ) : (
-                <p>Viewing availability from all volunteers</p>
+                <>
+                  <div className="session-details-div">
+                    <h1>Book 1:1 session</h1>
+                    <p className="session-icon-text-line">Viewing availability from all volunteers</p>
+                  </div>
+                </>
               ))}
 
             {!selectedTime && (

--- a/Frontend/src/components/pages/TraineeBookingFlow.jsx
+++ b/Frontend/src/components/pages/TraineeBookingFlow.jsx
@@ -15,6 +15,7 @@ import {
   parseLocalDate,
   parseLocalDateTime,
   formatLocalDate,
+  formatLocalTime
 } from "../../utilities/dateTime";
 
 const TraineeBookingFlow = () => {
@@ -112,7 +113,7 @@ const TraineeBookingFlow = () => {
   );
   for (let slot of sortedSlots) {
     const convertedToString = slot.start_time;
-    const dateOnlyStr = convertedToString.split("T")[0];
+    const dateOnlyStr = formatLocalDate(new Date(convertedToString));
 
     if (
       !convertedAllVDataToFrontendFormat.availableDates.includes(dateOnlyStr)
@@ -120,10 +121,8 @@ const TraineeBookingFlow = () => {
       convertedAllVDataToFrontendFormat.availableDates.push(dateOnlyStr);
     }
 
-    if (selectedDate && convertedToString.split("T")[0] === selectedDate) {
-      const timeOnlyStr = convertedToString.split("T")[1];
-      const timeInFormathhmm =
-        timeOnlyStr.split(":")[0] + ":" + timeOnlyStr.split(":")[1];
+    if (selectedDate && dateOnlyStr === selectedDate) {
+      const timeInFormathhmm = formatLocalTime(new Date(convertedToString));
 
       const slotKey = `${timeInFormathhmm}-${slot.volunteer_id}-${slot.slot_rule_id}`;
 

--- a/Frontend/src/components/pages/VolunteerDash.jsx
+++ b/Frontend/src/components/pages/VolunteerDash.jsx
@@ -140,7 +140,7 @@ const VolunteerDash = () => {
     <div className="booking-box">
       <div className="session-details-col">
         <SessionDetailsVolunteer
-          activeVolunteerProps={activeVolunteer}
+          user={activeVolunteer}
           onManageAvailabilityClick={() => setShowManager(true)}
         />
       </div>

--- a/Frontend/src/components/pages/VolunteerDash.jsx
+++ b/Frontend/src/components/pages/VolunteerDash.jsx
@@ -3,7 +3,7 @@ import { useParams } from "react-router-dom";
 import { volunteersDetails, traineeDetails } from "../../data/UserData";
 import { bookedSessions } from "../../data/BookedSessions";
 import BookingCard from "../groups/BookingCard";
-import SessionDetails from "../groups/SessionDetails";
+import SessionDetailsVolunteer from "../groups/SessionDetailsVolunteer";
 import VolunteerEditSession from "../groups/VolunteerEditSession";
 import VolunteerViewSession from "../groups/VolunteerViewSession";
 import VolunteerAvailabilityManager from "../groups/VolunteerAvailabilityManager";
@@ -139,9 +139,8 @@ const VolunteerDash = () => {
   return (
     <div className="booking-box">
       <div className="session-details-col">
-        <SessionDetails
+        <SessionDetailsVolunteer
           activeVolunteerProps={activeVolunteer}
-          volunteerView={true}
           onManageAvailabilityClick={() => setShowManager(true)}
         />
       </div>

--- a/Frontend/src/index.css
+++ b/Frontend/src/index.css
@@ -100,7 +100,9 @@
   .session-details-div h1 {
     @apply mt-3;
   }
-
+  .session-icon-div {
+    @apply flex flex-col justify-between flex-1;
+  }
   .session-icon-text-line {
     @apply mt-2 flex w-full items-center gap-2 text-muted;
   }

--- a/Frontend/src/index.css
+++ b/Frontend/src/index.css
@@ -149,7 +149,7 @@
   }
 
   .avatar {
-    @apply mb-2;
+    @apply mb-2 h-16 w-16 rounded-full object-cover;
   }
 
   /* MIDDLE CALENDAR */
@@ -227,7 +227,10 @@
   .btn-confirm {
     @apply rounded-full bg-brand-primary px-10 py-3 text-sm font-bold text-white transition-transform hover:opacity-90 active:scale-95;
   }
-
+  .btn-with-icon {
+		@apply inline-flex items-center gap-2 mt-2 p-2 border border-border-color rounded-lg text-main transition-all;
+		@apply hover:bg-black/5 hover:text-brand-blue;
+	}
   /* BOOKING FORM */
   .booking-form-container {
     @apply flex w-full flex-col items-start;

--- a/Frontend/src/index.css
+++ b/Frontend/src/index.css
@@ -101,7 +101,7 @@
     @apply mt-3;
   }
   .session-icon-div {
-    @apply flex flex-col justify-between flex-1;
+    @apply flex flex-1 flex-col justify-between;
   }
   .session-icon-text-line {
     @apply mt-2 flex w-full items-center gap-2 text-muted;
@@ -230,9 +230,9 @@
     @apply rounded-full bg-brand-primary px-10 py-3 text-sm font-bold text-white transition-transform hover:opacity-90 active:scale-95;
   }
   .btn-with-icon {
-		@apply inline-flex items-center gap-2 mt-2 p-2 border border-border-color rounded-lg text-main transition-all;
-		@apply hover:bg-black/5 hover:text-brand-blue;
-	}
+    @apply mt-2 inline-flex items-center gap-2 rounded-lg border border-border-color p-2 text-main transition-all;
+    @apply hover:bg-black/5 hover:text-brand-blue;
+  }
   /* BOOKING FORM */
   .booking-form-container {
     @apply flex w-full flex-col items-start;


### PR DESCRIPTION
SessionDetails component is separated into volunteer and trainee components, and styling is applied from https://github.com/SaraTahir28/Pair-Scheduling-APP/pull/163 

Changes:
- use Auth is removed from SessionDetails 
- volunteerDash sends user as props.

```
On TraineeBookingFlow:
<SessionDetails
  selectedDateProps={selectedDateObj}
  activeVolunteerProps={activeVolunteer}
/>

On VolunteerDash:
<SessionDetailsVolunteer
  user={activeVolunteer}
  onManageAvailabilityClick={() => setShowManager(true)}
/>
```