### PR TITLE
switch static storage to CompressedStaticFilesStorage

### DIFF
--- a/Backend/booking_system/settings.py
+++ b/Backend/booking_system/settings.py
@@ -222,7 +222,7 @@ STATIC_URL = "static/"
 STATIC_ROOT = BASE_DIR / "staticfiles"
 STORAGES = {
     "staticfiles": {
-        "BACKEND": "whitenoise.storage.CompressedManifestStaticFilesStorage",
+        "BACKEND": "whitenoise.storage.CompressedStaticFilesStorage",
     },
 }
 


### PR DESCRIPTION


Updated the WhiteNoise storage backend by removing the Manifest requirement. This change ensures files are still compressed for deployment while avoiding issues with missing manifest entries for dynamically referenced assets.