### PR TITLE
Feature/Authorization

### DIFF
--- a/Backend/core/tests/test_authorization.py
+++ b/Backend/core/tests/test_authorization.py
@@ -71,3 +71,31 @@ def test_admin_can_promote_user_to_admin(api_client):
 
     assert response.status_code == 200
     assert response.data["role"] == "admin"
+
+
+@pytest.mark.django_db
+def test_admin_can_demote_an_admin(api_client):
+    admin = User.objects.create_user(
+        username="main_admin",
+        email="main_admin@example.com",
+        password="securepass123",
+        role="admin",
+        status="active",
+    )
+
+    other_admin = User.objects.create_user(
+        username="other_admin",
+        email="other_admin@example.com",
+        password="securepass123",
+        role="admin",
+        status="active",
+    )
+
+    # Authenticate as the main admin
+    api_client.force_authenticate(user=admin)
+    # Admin demotes the other admin to volunteer
+    url = reverse("user-detail", args=[other_admin.id])
+    response = api_client.patch(url, {"role": "volunteer"}, format="json")
+
+    assert response.status_code == 200
+    assert response.data["role"] == "volunteer"

--- a/Backend/core/tests/test_authorization.py
+++ b/Backend/core/tests/test_authorization.py
@@ -99,3 +99,31 @@ def test_admin_can_demote_an_admin(api_client):
 
     assert response.status_code == 200
     assert response.data["role"] == "volunteer"
+
+
+@pytest.mark.django_db
+def test_non_admin_cannot_demote_an_admin(api_client):
+    non_admin = User.objects.create_user(
+        username="volunteer_user",
+        email="volunteer@example.com",
+        password="securepass342",
+        role="volunteer",  # or a "trainee"
+        status="active",
+    )
+
+    admin_user = User.objects.create_user(
+        username="sara",
+        email="sara@example.com",
+        password="securepass123",
+        role="admin",
+        status="active",
+    )
+
+    # Authenticate as the non-admin user
+    api_client.force_authenticate(user=non_admin)
+
+    # Attempt to demote the admin to volunteer
+    url = reverse("user-detail", args=[admin_user.id])
+    response = api_client.patch(url, {"role": "volunteer"}, format="json")
+
+    assert response.status_code == 403

--- a/Backend/core/tests/test_authorization.py
+++ b/Backend/core/tests/test_authorization.py
@@ -26,3 +26,19 @@ def test_trainee_cannot_promote_to_admin(api_client):
     response = api_client.patch(url, {"role": "admin"}, format="json")
 
     assert response.status_code == 403
+
+
+@pytest.mark.django_db
+def test_volunteer_cannot_promote_themselves_to_admin(api_client):
+    volunteer = User.objects.create_user(
+        username="Emiliano",
+        email="emiliano@example.com",
+        password="securepass456",
+        role="volunteer",
+        status="active",
+    )
+
+    api_client.force_authenticate(user=volunteer)
+    url = reverse("user-detail", args=[volunteer.id])
+    response = api_client.patch(url, {"role": "admin"}, format="json")
+    assert response.status_code == 403

--- a/Backend/core/tests/test_authorization.py
+++ b/Backend/core/tests/test_authorization.py
@@ -42,3 +42,32 @@ def test_volunteer_cannot_promote_themselves_to_admin(api_client):
     url = reverse("user-detail", args=[volunteer.id])
     response = api_client.patch(url, {"role": "admin"}, format="json")
     assert response.status_code == 403
+
+
+@pytest.mark.django_db
+def test_admin_can_promote_user_to_admin(api_client):
+    admin = User.objects.create_user(
+        username="sara",
+        email="sara@example.com",
+        password="securepass123",
+        role="admin",
+        status="active",
+    )
+
+    target = User.objects.create_user(
+        username="kaska",
+        email="kaska@example.com",
+        password="securepass123",
+        role="trainee",
+        status="active",
+    )
+
+    # Authenticate as the admin
+    api_client.force_authenticate(user=admin)
+
+    # Admin promotes the target user to admin
+    url = reverse("user-detail", args=[target.id])
+    response = api_client.patch(url, {"role": "admin"}, format="json")
+
+    assert response.status_code == 200
+    assert response.data["role"] == "admin"

--- a/Backend/core/tests/test_authorization.py
+++ b/Backend/core/tests/test_authorization.py
@@ -1,0 +1,28 @@
+import pytest
+from django.urls import reverse
+from rest_framework.test import APIClient
+
+from core.models import User
+
+
+@pytest.fixture
+def api_client():
+    return APIClient()
+
+
+@pytest.mark.django_db
+def test_trainee_cannot_promote_to_admin(api_client):
+    trainee = User.objects.create_user(
+        username="sara",
+        email="sara@example.com",
+        password="securepass123",
+        role="trainee",
+        status="active",
+    )
+
+    api_client.force_authenticate(user=trainee)
+
+    url = reverse("user-detail", args=[trainee.id])
+    response = api_client.patch(url, {"role": "admin"}, format="json")
+
+    assert response.status_code == 403

--- a/Backend/core/user_serializers.py
+++ b/Backend/core/user_serializers.py
@@ -1,4 +1,5 @@
 from rest_framework import serializers
+from rest_framework.exceptions import PermissionDenied
 
 from .models import User
 
@@ -83,3 +84,18 @@ class UserSerializer(serializers.ModelSerializer):
         user.save()
 
         return user
+
+    def update(self, instance, validated_data):
+        request = self.context["request"]
+
+        # Prevent privilege escalation
+        if "role" in validated_data:
+            new_role = validated_data["role"]
+
+            if new_role == "admin" and request.user.role != "admin":
+                raise PermissionDenied(
+                    "You do not have permission to assign the admin role."
+                )
+            print("SERIALIZER UPDATE CALLED")
+
+        return super().update(instance, validated_data)

--- a/Backend/core/user_serializers.py
+++ b/Backend/core/user_serializers.py
@@ -96,6 +96,7 @@ class UserSerializer(serializers.ModelSerializer):
                 raise PermissionDenied(
                     "You do not have permission to assign the admin role."
                 )
-            print("SERIALIZER UPDATE CALLED")
+            if instance.role == "admin" and request.user.role != "admin":
+                raise PermissionDenied("You cannot modofy and admins role.")
 
         return super().update(instance, validated_data)


### PR DESCRIPTION
This PR close #183  and does backend authorization by ensuring that only admin users can modify user roles, and that non‑admin users cannot assign or remove the admin role. The update closes a security gap where a malicious user could previously bypass the frontend and escalate privileges via direct API calls.

1.**Serializer Update**
 UserSerializer updated to enforce strict role‑change rules at the backend level.

The serializer now
**Prevents non‑admin users from:**

1. Assigning the admin role to themselves or others
2. Demoting an existing admin

**Allows admin users to**

1. Promote any user to admin
2. Demote any admin to a non‑admin role

2.**Test Suite**

1. Trainee/volunteer cannot promote themselves to admin
2. Trainee/volunteer cannot promote any other user to admin
3. Trainee/volunteer cannot demote an admin
4. Admin can promote a user to admin
5. Admin can demote another admin

All tests pass successfully

3. **Manual Security Verification (Browser DevTools)**
To validate the backend protection beyond automated tests, we manually attempted to bypass the frontend using direct PATCH requests executed via fetch() in the browser DevTools console.

**What we verified:**

1. The browser sends valid session + CSRF cookies
2. Unauthorized users receive 403 Forbidden when attempting to escalate privileges
3. Admin users can successfully promote/demote roles
4. The backend blocks privilege escalation even when the UI is bypassed

This confirms that the API is now protected against direct privilege‑escalation attempts.

**Expected Behavior** 

1. Admin RBAC is enforced 
2. All automated tests pass
3. Manual DevTools attacks confirm the system is secure
4. The API is now protected against privilege‑escalation attempts