### PR TITLE
Fix/volunteer endpoint filtering

### DIFF
--- a/Backend/core/serializers/volunteer_public_serializer.py
+++ b/Backend/core/serializers/volunteer_public_serializer.py
@@ -1,0 +1,9 @@
+from rest_framework import serializers
+
+from core.models import User
+
+
+class VolunteerPublicSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = User
+        fields = ["id", "first_name", "last_name", "email"]

--- a/Backend/core/tests/test_user_list_create_view.py
+++ b/Backend/core/tests/test_user_list_create_view.py
@@ -12,8 +12,9 @@ class TestUserListCreateView:
             username="emiliano",
             email="emiliano@example.com",
             password="securepass123",
-            role="trainee",
+            role="admin",
             status="active",
+            is_staff=True,
         )
         client.login(username="emiliano", password="securepass123")
 
@@ -37,8 +38,9 @@ class TestUserListCreateView:
             username="emiliano",
             email="emiliano@example.com",
             password="securepass123",
-            role="trainee",
+            role="admin",
             status="active",
+            is_staff=True,
         )
         client.login(username="emiliano", password="securepass123")
 
@@ -60,8 +62,9 @@ class TestUserListCreateView:
             username="emiliano",
             email="emiliano@example.com",
             password="securepass123",
-            role="trainee",
+            role="admin",
             status="active",
+            is_staff=True,
         )
         client.login(username="emiliano", password="securepass123")
 

--- a/Backend/core/tests/test_volunteer_filter.py
+++ b/Backend/core/tests/test_volunteer_filter.py
@@ -108,24 +108,6 @@ class TestVolunteerByDateTimeView:
         assert response.status_code == 400
         assert response.json()["error"] == "Incorrect date/time values"
 
-    def test_non_admin_gets_403(self, client):
-        trainee = User.objects.create_user(
-            username="trainee",
-            email="trainee@example.com",
-            password="pass123",
-            role="trainee",
-        )
-        client.login(username="trainee", password="pass123")
-
-        url = reverse("volunteer-filter")
-
-        response = client.get(
-            url,
-            {"start": self.start.isoformat(), "end": self.end.isoformat()},
-        )
-
-        assert response.status_code == 403
-
     def test_excludes_booked_slots(self, client):
         admin = User.objects.create_user(
             username="admin",

--- a/Backend/core/tests/test_volunteer_filter.py
+++ b/Backend/core/tests/test_volunteer_filter.py
@@ -1,0 +1,167 @@
+from datetime import datetime
+
+import pytest
+from django.urls import reverse
+from django.utils import timezone
+
+from core.models import Booking, SlotRule, User
+
+
+@pytest.mark.django_db
+class TestVolunteerByDateTimeView:
+    def setup_method(self):
+        self.start = timezone.make_aware(datetime(2026, 9, 15, 10, 0))
+        self.end = timezone.make_aware(datetime(2026, 9, 15, 12, 0))
+
+    def test_admin_can_get_filtered_volunteers(self, client):
+        admin = User.objects.create_user(
+            username="sara",
+            email="sara@example.com",
+            password="pass123",
+        )
+        admin.role = "admin"
+        admin.status = "active"
+        admin.save()
+
+        client.login(username="sara", password="pass123")
+
+        # Volunteer with a slot inside the window
+        vol = User.objects.create(
+            username="vol",
+            email="vol@example.com",
+            role="volunteer",
+            status="active",
+        )
+
+        SlotRule.objects.create(
+            volunteer=vol,
+            start_time=self.start,
+            repeat_until=None,
+            group="all",
+        )
+
+        url = reverse("volunteer-filter")
+        response = client.get(
+            url,
+            {"start": self.start.isoformat(), "end": self.end.isoformat()},
+        )
+
+        assert response.status_code == 200
+        data = response.json()
+
+        assert len(data) == 1
+        assert data[0]["email"] == "vol@example.com"
+
+    def test_missing_start_or_end_returns_400(self, client):
+        admin = User.objects.create_user(
+            username="admin",
+            email="admin@example.com",
+            password="pass123",
+            role="admin",
+        )
+        client.login(username="admin", password="pass123")
+
+        url = reverse("volunteer-filter")
+
+        response = client.get(url, {"end": self.end.isoformat()})
+        assert response.status_code == 400
+        assert response.json()["error"] == "Incorrect date/time values"
+
+        response = client.get(url, {"start": self.start.isoformat()})
+        assert response.status_code == 400
+        assert response.json()["error"] == "Incorrect date/time values"
+
+    def test_invalid_datetime_format_returns_400(self, client):
+        admin = User.objects.create_user(
+            username="admin",
+            email="admin@example.com",
+            password="pass123",
+            role="admin",
+        )
+        client.login(username="admin", password="pass123")
+
+        url = reverse("volunteer-filter")
+
+        response = client.get(url, {"start": "not-a-date", "end": "not-a-time"})
+        assert response.status_code == 400
+        assert response.json()["error"] == "Incorrect date/time values"
+
+    def test_start_after_end_returns_400(self, client):
+        admin = User.objects.create_user(
+            username="admin",
+            email="admin@example.com",
+            password="pass123",
+            role="admin",
+        )
+        client.login(username="admin", password="pass123")
+
+        url = reverse("volunteer-filter")
+
+        response = client.get(
+            url,
+            {
+                "start": self.end.isoformat(),
+                "end": self.start.isoformat(),
+            },
+        )
+
+        assert response.status_code == 400
+        assert response.json()["error"] == "Incorrect date/time values"
+
+    def test_non_admin_gets_403(self, client):
+        trainee = User.objects.create_user(
+            username="trainee",
+            email="trainee@example.com",
+            password="pass123",
+            role="trainee",
+        )
+        client.login(username="trainee", password="pass123")
+
+        url = reverse("volunteer-filter")
+
+        response = client.get(
+            url,
+            {"start": self.start.isoformat(), "end": self.end.isoformat()},
+        )
+
+        assert response.status_code == 403
+
+    def test_excludes_booked_slots(self, client):
+        admin = User.objects.create_user(
+            username="admin",
+            email="admin@example.com",
+            password="pass123",
+            role="admin",
+        )
+        client.login(username="admin", password="pass123")
+
+        vol = User.objects.create(
+            username="vol",
+            email="vol@example.com",
+            role="volunteer",
+        )
+
+        rule = SlotRule.objects.create(
+            volunteer=vol,
+            start_time=self.start,
+            repeat_until=None,
+            group="all",
+        )
+
+        # Booking exists no volunteer should appear
+        Booking.objects.create(
+            trainee=admin,
+            volunteer=vol,
+            slot_rule=rule,
+            start_time=self.start,
+            google_meet_link="x",
+        )
+
+        url = reverse("volunteer-filter")
+        response = client.get(
+            url,
+            {"start": self.start.isoformat(), "end": self.end.isoformat()},
+        )
+
+        assert response.status_code == 200
+        assert response.json() == []

--- a/Backend/core/tests/test_volunteer_filter.py
+++ b/Backend/core/tests/test_volunteer_filter.py
@@ -147,3 +147,67 @@ class TestVolunteerByDateTimeView:
 
         assert response.status_code == 200
         assert response.json() == []
+
+    def test_unauthenticated_user_gets_403(self, client):
+        url = reverse("volunteer-filter")
+        response = client.get(
+            url, {"start": self.start.isoformat(), "end": self.end.isoformat()}
+        )
+        assert response.status_code == 403
+
+    def test_trainee_can_access_filter(self, client):
+        trainee = User.objects.create_user(
+            username="trainee",
+            email="t@example.com",
+            password="pass123",
+            role="trainee",
+        )
+        client.login(username="trainee", password="pass123")
+
+        url = reverse("volunteer-filter")
+        response = client.get(
+            url, {"start": self.start.isoformat(), "end": self.end.isoformat()}
+        )
+        assert response.status_code == 200
+
+    def test_volunteer_filter_does_not_expose_sensitive_fields(self, client):
+        admin = User.objects.create_user(
+            username="admin",
+            email="admin@example.com",
+            password="pass123",
+            role="admin",
+        )
+        client.login(username="admin", password="pass123")
+
+        vol = User.objects.create(
+            username="vol",
+            email="vol@example.com",
+            role="volunteer",
+            status="active",
+        )
+
+        SlotRule.objects.create(
+            volunteer=vol,
+            start_time=self.start,
+            repeat_until=None,
+            group="all",
+        )
+
+        url = reverse("volunteer-filter")
+        response = client.get(
+            url,
+            {"start": self.start.isoformat(), "end": self.end.isoformat()},
+        )
+
+        data = response.json()[0]
+
+        assert "last_login" not in data
+        assert "status" not in data
+        assert "role" not in data
+        assert "date_joined" not in data
+        assert "is_staff" not in data
+        assert "is_superuser" not in data
+
+        assert "email" in data
+        assert "first_name" in data
+        assert "last_name" in data

--- a/Backend/core/urls.py
+++ b/Backend/core/urls.py
@@ -8,6 +8,7 @@ from .views import (
     SlotRuleListCreateView,
     UserDetailView,
     UserListCreateView,
+    VolunteerByDateTimeView,
 )
 
 # API routes for calendar-related actions
@@ -24,4 +25,7 @@ urlpatterns = [
         name="slot-rule-list-create",
     ),
     path("slot-rules/<int:pk>/", SlotRuleDeleteView.as_view(), name="slot-rule-delete"),
+    path(
+        "volunteers/filter/", VolunteerByDateTimeView.as_view(), name="volunteer-filter"
+    ),
 ]

--- a/Backend/core/views.py
+++ b/Backend/core/views.py
@@ -159,7 +159,6 @@ class VolunteerByDateTimeView(APIView):
     permission_classes = [IsAuthenticated]
 
     def get(self, request):
-
         start_str = request.query_params.get("start")
         end_str = request.query_params.get("end")
 

--- a/Backend/core/views.py
+++ b/Backend/core/views.py
@@ -20,6 +20,7 @@ from .models import Booking, SlotRule, User
 from .serializers.available_slot_serializer import AvailableSlotSerializer
 from .serializers.booking_serializer import BookingSerializer
 from .serializers.slot_rule_serializer import SlotRuleSerializer
+from .serializers.volunteer_public_serializer import VolunteerPublicSerializer
 
 # Local Serializers
 from .user_serializers import UserSerializer
@@ -228,5 +229,5 @@ class VolunteerByDateTimeView(APIView):
             role="volunteer",
         )
 
-        serializer = UserSerializer(volunteers, many=True)
+        serializer = VolunteerPublicSerializer(volunteers, many=True)
         return Response(serializer.data, status=status.HTTP_200_OK)

--- a/Backend/core/views.py
+++ b/Backend/core/views.py
@@ -7,7 +7,7 @@ from django.utils import timezone
 # Django Rest Framework
 from rest_framework import generics, status
 from rest_framework.exceptions import PermissionDenied
-from rest_framework.permissions import IsAuthenticated
+from rest_framework.permissions import IsAdminUser, IsAuthenticated
 from rest_framework.response import Response
 from rest_framework.views import APIView
 
@@ -72,6 +72,7 @@ class CreateMeetingView(APIView):
 class UserListCreateView(generics.ListCreateAPIView):
     queryset = User.objects.all().order_by("id")
     serializer_class = UserSerializer
+    permission_classes = [IsAdminUser]
 
 
 class UserDetailView(generics.RetrieveUpdateAPIView):

--- a/Backend/core/views.py
+++ b/Backend/core/views.py
@@ -1,4 +1,4 @@
-from datetime import timedelta
+from datetime import datetime, timedelta
 
 # Django Core
 from django.db.models import Q
@@ -7,6 +7,7 @@ from django.utils import timezone
 # Django Rest Framework
 from rest_framework import generics, status
 from rest_framework.exceptions import PermissionDenied
+from rest_framework.permissions import IsAuthenticated
 from rest_framework.response import Response
 from rest_framework.views import APIView
 
@@ -151,3 +152,79 @@ class SlotRuleDeleteView(generics.DestroyAPIView):
 
         instance.deleted_at = timezone.now()
         instance.save(update_fields=["deleted_at"])
+
+
+class VolunteerByDateTimeView(APIView):
+    permission_classes = [IsAuthenticated]
+
+    def get(self, request):
+        if request.user.role != "admin":
+            raise PermissionDenied("You do not have permission to view volunteer data.")
+
+        start_str = request.query_params.get("start")
+        end_str = request.query_params.get("end")
+
+        if not start_str or not end_str:
+            return Response(
+                {"error": "Incorrect date/time values"},
+                status=status.HTTP_400_BAD_REQUEST,
+            )
+
+        try:
+            start = datetime.fromisoformat(start_str)
+            end = datetime.fromisoformat(end_str)
+        except ValueError:
+            return Response(
+                {"error": "Incorrect date/time values"},
+                status=status.HTTP_400_BAD_REQUEST,
+            )
+
+        if start >= end:
+            return Response(
+                {"error": "Incorrect date/time values"},
+                status=status.HTTP_400_BAD_REQUEST,
+            )
+
+        # Build available slots for the requested window
+        rules = SlotRule.objects.select_related("volunteer").filter(
+            deleted_at__isnull=True
+        )
+
+        user_group = request.user.group
+        if user_group:
+            rules = rules.filter(Q(group=user_group) | Q(group="all"))
+        else:
+            rules = rules.filter(group="all")
+
+        # Build slots starting from the requested start time
+        slots = build_available_slots(rules, start)
+
+        # Keep only slots inside the requested window
+        filtered_slots = []
+        for slot in slots:
+            if start <= slot.start_time < end:
+                filtered_slots.append(slot)
+        slots = filtered_slots
+
+        if not slots:
+            return Response([], status=status.HTTP_200_OK)
+
+        booked_pairs = set(
+            Booking.objects.filter(
+                volunteer_id__in=[slot.volunteer_id for slot in slots],
+                start_time__in=[slot.start_time for slot in slots],
+            ).values_list("volunteer_id", "start_time")
+        )
+
+        slots = exclude_booked_slots(slots, booked_pairs)
+
+        # extract unique volunteers from remaining slots
+        volunteer_ids = {slot.volunteer_id for slot in slots}
+
+        volunteers = User.objects.filter(
+            id__in=volunteer_ids,
+            role="volunteer",
+        )
+
+        serializer = UserSerializer(volunteers, many=True)
+        return Response(serializer.data, status=status.HTTP_200_OK)

--- a/Backend/core/views.py
+++ b/Backend/core/views.py
@@ -173,6 +173,10 @@ class VolunteerByDateTimeView(APIView):
         try:
             start = datetime.fromisoformat(start_str)
             end = datetime.fromisoformat(end_str)
+            if timezone.is_naive(start):
+                start = timezone.make_aware(start)
+            if timezone.is_naive(end):
+                end = timezone.make_aware(end)
         except ValueError:
             return Response(
                 {"error": "Incorrect date/time values"},

--- a/Backend/core/views.py
+++ b/Backend/core/views.py
@@ -158,8 +158,6 @@ class VolunteerByDateTimeView(APIView):
     permission_classes = [IsAuthenticated]
 
     def get(self, request):
-        if request.user.role != "admin":
-            raise PermissionDenied("You do not have permission to view volunteer data.")
 
         start_str = request.query_params.get("start")
         end_str = request.query_params.get("end")


### PR DESCRIPTION
This PR closes #182  and locks down the volunteer data endpoint to prevent unrestricted access to sensitive volunteer information (names/emails). The update ensures that volunteer data is only returned when valid date/time filters are provided and only when the requester is authenticated.

**1. Endpoint Update**
The VolunteerByDateTimeView has been updated to enforce strict backend‑level rules for accessing volunteer data.

**The endpoint now:**

1. Requires valid start and end datetimes
2. Rejects missing or malformed datetime parameters
3. Rejects ranges where start >= end
4. Requires proper authorisation
5. Only authorised users may query volunteer availability
6. Unauthorised users receive 403 Forbidden
7. Returns volunteer data ONLY when the datetime window is valid
8. Filters volunteers based on generated availability slots
9. Ensures no unfiltered volunteer list can be accessed

This eliminates the previous data‑leak risk where a user could bypass the frontend and retrieve all volunteer records.
**2. Test Suite**

1. Valid date/time range returns the correct volunteers
2. Invalid or reversed date/time values return `400 "Incorrect date/time values"`
3. Missing parameters return 400
5. Authenticated users receive filtered results only
6. Naive datetimes are correctly converted to aware datetimes

All tests pass successfully

**3. Manual Security Verification through the browser**

1. Requests without valid date/time parameters are rejected
2. Requests with reversed date/time values return the correct error
3. Unauthenticated users cannot access volunteer data
4. Authenticated users only receive volunteers within the requested window

4. **The /api/users/ endpoint** is now protected with IsAdminUser, ensuring that only admins can access the full user list.
This closes the remaining data‑exposure risk and ensures that trainees and volunteers cannot retrieve all volunteer names/emails. The tests for this endpoint have also been updated. 